### PR TITLE
feat: release pipeline (Linux AppImage + Windows zip) + Apache-2.0 licensing

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -9,8 +9,15 @@ if ! command -v clang-format >/dev/null 2>&1; then
     exit 1
 fi
 
-clang-format -i -- src/**/*.cpp
-clang-format -i -- src/**/*.h
+shopt -s globstar nullglob
+files=(src/**/*.cpp src/**/*.h tests/**/*.cpp tests/**/*.h)
+if (( ${#files[@]} )); then
+    clang-format -i -- "${files[@]}"
+fi
 
-cmake --build --preset user-ninja-multi-vcpkglt
-ctest --preset user-ninja-multi-vcpkglt
+# Optional (slow): build + test before commit.
+if [[ "${HB_PRECOMMIT_RUN_TESTS:-0}" == "1" ]]; then
+    preset="${HB_PRECOMMIT_CMAKE_PRESET:-ninja-multi-vcpkg}"
+    cmake --build --preset "$preset"
+    ctest --preset "$preset"
+fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,8 +69,25 @@ jobs:
               Copy-Item (Join-Path $PWD $dir) (Join-Path $bundleDir $dir) -Recurse -Force
             }
           }
-          if (Test-Path (Join-Path $PWD "licenses")) {
-            Copy-Item (Join-Path $PWD "licenses") (Join-Path $bundleDir "licenses") -Recurse -Force
+
+          $licensesDir = Join-Path $bundleDir "licenses"
+          New-Item -ItemType Directory -Force -Path $licensesDir | Out-Null
+          if (Test-Path (Join-Path $PWD "LICENSE")) {
+            Copy-Item (Join-Path $PWD "LICENSE") (Join-Path $licensesDir "Hummingbird-LICENSE.txt") -Force
+          }
+          if (Test-Path (Join-Path $PWD "NOTICE")) {
+            Copy-Item (Join-Path $PWD "NOTICE") (Join-Path $licensesDir "Hummingbird-NOTICE.txt") -Force
+          }
+
+          # Bundle vcpkg port license notices (best-effort)
+          $vcpkgInstalled = Join-Path $PWD "vcpkg_installed"
+          if (Test-Path $vcpkgInstalled) {
+            Get-ChildItem -Path $vcpkgInstalled -Recurse -File -Filter copyright -ErrorAction SilentlyContinue |
+              Where-Object { $_.FullName -match "[\\\\/]share[\\\\/][^\\\\/]+[\\\\/]copyright$" } |
+              ForEach-Object {
+                $port = Split-Path (Split-Path $_.FullName -Parent) -Leaf
+                Copy-Item $_.FullName (Join-Path $licensesDir ("vcpkg-" + $port + ".txt")) -Force
+              }
           }
 
           # Copy DLLs next to exe (common case)
@@ -78,7 +95,6 @@ jobs:
             ForEach-Object { Copy-Item $_.FullName $bundleDir -Force }
 
           # Best-effort: also copy vcpkg installed bin DLLs
-          $vcpkgInstalled = Join-Path $PWD "vcpkg_installed"
           if (Test-Path $vcpkgInstalled) {
             Get-ChildItem -Path $vcpkgInstalled -Recurse -Filter "*.dll" -File -ErrorAction SilentlyContinue |
               ForEach-Object { Copy-Item $_.FullName $bundleDir -Force }
@@ -156,8 +172,17 @@ jobs:
               cp -R "$d" "AppDir/usr/share/hummingbird/$d"
             fi
           done
-          if [[ -d "licenses" ]]; then
-            cp -R "licenses" "AppDir/usr/share/hummingbird/licenses"
+
+          mkdir -p AppDir/usr/share/hummingbird/licenses/vcpkg
+          cp LICENSE AppDir/usr/share/hummingbird/licenses/Hummingbird-LICENSE.txt
+          if [[ -f NOTICE ]]; then
+            cp NOTICE AppDir/usr/share/hummingbird/licenses/Hummingbird-NOTICE.txt
+          fi
+          if [[ -d "vcpkg_installed" ]]; then
+            while IFS= read -r -d '' f; do
+              port="$(basename "$(dirname "$f")")"
+              cp "$f" "AppDir/usr/share/hummingbird/licenses/vcpkg/${port}.txt"
+            done < <(find vcpkg_installed -type f -path "*/share/*/copyright" -print0)
           fi
 
           cat > AppDir/hummingbird.desktop <<'EOF'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,14 +80,27 @@ jobs:
           }
 
           # Bundle vcpkg port license notices (best-effort)
-          $vcpkgInstalled = Join-Path $PWD "vcpkg_installed"
-          if (Test-Path $vcpkgInstalled) {
-            Get-ChildItem -Path $vcpkgInstalled -Recurse -File -Filter copyright -ErrorAction SilentlyContinue |
-              Where-Object { $_.FullName -match "[\\\\/]share[\\\\/][^\\\\/]+[\\\\/]copyright$" } |
-              ForEach-Object {
-                $port = Split-Path (Split-Path $_.FullName -Parent) -Leaf
-                Copy-Item $_.FullName (Join-Path $licensesDir ("vcpkg-" + $port + ".txt")) -Force
-              }
+          $vcpkgCandidates = @(
+            (Join-Path $PWD "build/vcpkg_installed"),
+            (Join-Path $PWD "vcpkg_installed")
+          )
+          $vcpkgRoots = $vcpkgCandidates | Where-Object { Test-Path $_ }
+          if ($vcpkgRoots.Count -gt 0) {
+            $vcpkgLicensesDir = Join-Path $licensesDir "vcpkg"
+            New-Item -ItemType Directory -Force -Path $vcpkgLicensesDir | Out-Null
+
+            $copied = 0
+            foreach ($root in $vcpkgRoots) {
+              Get-ChildItem -Path $root -Recurse -File -Filter copyright -ErrorAction SilentlyContinue |
+                ForEach-Object {
+                  if ($_.FullName -match "[\\\\/]share[\\\\/]([^\\\\/]+)[\\\\/]copyright$") {
+                    $port = $Matches[1]
+                    Copy-Item $_.FullName (Join-Path $vcpkgLicensesDir ($port + ".txt")) -Force
+                    $copied++
+                  }
+                }
+            }
+            Write-Host "Bundled $copied vcpkg license file(s) into $vcpkgLicensesDir"
           }
 
           # Copy DLLs next to exe (common case)
@@ -95,9 +108,11 @@ jobs:
             ForEach-Object { Copy-Item $_.FullName $bundleDir -Force }
 
           # Best-effort: also copy vcpkg installed bin DLLs
-          if (Test-Path $vcpkgInstalled) {
-            Get-ChildItem -Path $vcpkgInstalled -Recurse -Filter "*.dll" -File -ErrorAction SilentlyContinue |
-              ForEach-Object { Copy-Item $_.FullName $bundleDir -Force }
+          if ($vcpkgRoots.Count -gt 0) {
+            foreach ($root in $vcpkgRoots) {
+              Get-ChildItem -Path $root -Recurse -Filter "*.dll" -File -ErrorAction SilentlyContinue |
+                ForEach-Object { Copy-Item $_.FullName $bundleDir -Force }
+            }
           }
 
           $zipPath = Join-Path $distRoot ("Hummingbird-" + $ver + "-win64.zip")
@@ -178,12 +193,13 @@ jobs:
           if [[ -f NOTICE ]]; then
             cp NOTICE AppDir/usr/share/hummingbird/licenses/Hummingbird-NOTICE.txt
           fi
-          if [[ -d "vcpkg_installed" ]]; then
-            while IFS= read -r -d '' f; do
-              port="$(basename "$(dirname "$f")")"
-              cp "$f" "AppDir/usr/share/hummingbird/licenses/vcpkg/${port}.txt"
-            done < <(find vcpkg_installed -type f -path "*/share/*/copyright" -print0)
-          fi
+          copied=0
+          while IFS= read -r -d '' f; do
+            port="$(basename "$(dirname "$f")")"
+            cp "$f" "AppDir/usr/share/hummingbird/licenses/vcpkg/${port}.txt"
+            copied=$((copied + 1))
+          done < <(find . -type f -path "*/vcpkg_installed/*/share/*/copyright" -print0 2>/dev/null || true)
+          echo "Bundled ${copied} vcpkg license file(s) into AppDir/usr/share/hummingbird/licenses/vcpkg"
 
           cat > AppDir/hummingbird.desktop <<'EOF'
           [Desktop Entry]
@@ -209,7 +225,7 @@ jobs:
 
           # Make vcpkg libs visible for bundling
           # vcpkg_installed/**/lib is where shared libs typically live
-          VCPKG_LIB_DIR="$(find vcpkg_installed -type d -path "*/lib" | head -n 1 || true)"
+          VCPKG_LIB_DIR="$(find . -type d -path "*/vcpkg_installed/*/lib" | head -n 1 || true)"
           if [[ -n "${VCPKG_LIB_DIR}" ]]; then
             export LD_LIBRARY_PATH="${VCPKG_LIB_DIR}:${LD_LIBRARY_PATH:-}"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,224 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+
+env:
+  VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}/.vcpkg/bincache
+  VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}/.vcpkg/bincache,readwrite
+
+jobs:
+  windows_zip:
+    runs-on: windows-latest
+    name: Windows (portable zip)
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Cache vcpkg binary cache
+        uses: actions/cache@v4
+        with:
+          path: .vcpkg/bincache
+          key: vcpkg-${{ runner.os }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+          restore-keys: vcpkg-${{ runner.os }}-
+
+      - name: Setup MSVC
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Setup vcpkg (manifest)
+        uses: lukka/run-vcpkg@v11
+        with:
+          vcpkgJsonGlob: "vcpkg.json"
+
+      - name: Configure (preset)
+        run: cmake --preset ninja-multi-vcpkg
+
+      - name: Build (Release)
+        run: cmake --build --preset ninja-multi-vcpkg --config Release
+
+      - name: Test (Release)
+        run: ctest --preset ninja-multi-vcpkg -C Release --output-on-failure
+
+      - name: Stage + Zip
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $tag = "${{ github.ref_name }}"
+          $ver = $tag.TrimStart("v")
+
+          $exe = Join-Path $PWD "build/Release/Hummingbird.exe"
+          if (-not (Test-Path $exe)) { throw "Expected binary not found: $exe" }
+
+          $distRoot = Join-Path $PWD "dist"
+          $bundleDir = Join-Path $distRoot ("Hummingbird-" + $ver + "-win64")
+          New-Item -ItemType Directory -Force -Path $bundleDir | Out-Null
+
+          Copy-Item $exe (Join-Path $bundleDir "hummingbird.exe") -Force
+
+          foreach ($dir in @("assets", "resources")) {
+            if (Test-Path (Join-Path $PWD $dir)) {
+              Copy-Item (Join-Path $PWD $dir) (Join-Path $bundleDir $dir) -Recurse -Force
+            }
+          }
+          if (Test-Path (Join-Path $PWD "licenses")) {
+            Copy-Item (Join-Path $PWD "licenses") (Join-Path $bundleDir "licenses") -Recurse -Force
+          }
+
+          # Copy DLLs next to exe (common case)
+          Get-ChildItem -Path (Join-Path $PWD "build/Release") -Filter "*.dll" -File -ErrorAction SilentlyContinue |
+            ForEach-Object { Copy-Item $_.FullName $bundleDir -Force }
+
+          # Best-effort: also copy vcpkg installed bin DLLs
+          $vcpkgInstalled = Join-Path $PWD "vcpkg_installed"
+          if (Test-Path $vcpkgInstalled) {
+            Get-ChildItem -Path $vcpkgInstalled -Recurse -Filter "*.dll" -File -ErrorAction SilentlyContinue |
+              ForEach-Object { Copy-Item $_.FullName $bundleDir -Force }
+          }
+
+          $zipPath = Join-Path $distRoot ("Hummingbird-" + $ver + "-win64.zip")
+          if (Test-Path $zipPath) { Remove-Item $zipPath -Force }
+          Compress-Archive -Path $bundleDir -DestinationPath $zipPath
+          Write-Host "Created $zipPath"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows-zip
+          path: dist/*.zip
+
+  linux_appimage:
+    runs-on: ubuntu-latest
+    name: Linux (AppImage)
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Cache vcpkg binary cache
+        uses: actions/cache@v4
+        with:
+          path: .vcpkg/bincache
+          key: vcpkg-${{ runner.os }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+          restore-keys: vcpkg-${{ runner.os }}-
+
+      - name: System deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            ninja-build build-essential \
+            xvfb \
+            patchelf file curl
+
+      - name: Setup vcpkg (manifest)
+        uses: lukka/run-vcpkg@v11
+        with:
+          vcpkgJsonGlob: "vcpkg.json"
+
+      - name: Configure (preset)
+        run: cmake --preset ninja-multi-vcpkg
+
+      - name: Build (Release)
+        run: cmake --build --preset ninja-multi-vcpkg --config Release
+
+      - name: Test (Release, headless)
+        run: xvfb-run -a ctest --preset ninja-multi-vcpkg -C Release --output-on-failure
+
+      - name: Build AppImage
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
+          VER="${TAG#v}"
+
+          BIN="build/Release/Hummingbird"
+          if [[ ! -x "$BIN" ]]; then
+            echo "Expected binary not found or not executable: $BIN"
+            exit 1
+          fi
+
+          mkdir -p dist AppDir/usr/bin AppDir/usr/share/hummingbird
+
+          cp "$BIN" AppDir/usr/bin/hummingbird
+
+          for d in assets resources; do
+            if [[ -d "$d" ]]; then
+              cp -R "$d" "AppDir/usr/share/hummingbird/$d"
+            fi
+          done
+          if [[ -d "licenses" ]]; then
+            cp -R "licenses" "AppDir/usr/share/hummingbird/licenses"
+          fi
+
+          cat > AppDir/hummingbird.desktop <<'EOF'
+          [Desktop Entry]
+          Type=Application
+          Name=Hummingbird
+          Exec=hummingbird
+          Icon=hummingbird
+          Categories=Network;WebBrowser;
+          Terminal=false
+          EOF
+
+          # Minimal icon placeholder (replace later)
+          mkdir -p AppDir/usr/share/icons/hicolor/256x256/apps
+          if ! command -v convert >/dev/null 2>&1; then
+            sudo apt-get install -y imagemagick
+          fi
+          convert -size 256x256 xc:white AppDir/usr/share/icons/hicolor/256x256/apps/hummingbird.png
+          cp AppDir/usr/share/icons/hicolor/256x256/apps/hummingbird.png AppDir/hummingbird.png
+
+          curl -L -o linuxdeploy-x86_64.AppImage \
+            https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
+          chmod +x linuxdeploy-x86_64.AppImage
+
+          # Make vcpkg libs visible for bundling
+          # vcpkg_installed/**/lib is where shared libs typically live
+          VCPKG_LIB_DIR="$(find vcpkg_installed -type d -path "*/lib" | head -n 1 || true)"
+          if [[ -n "${VCPKG_LIB_DIR}" ]]; then
+            export LD_LIBRARY_PATH="${VCPKG_LIB_DIR}:${LD_LIBRARY_PATH:-}"
+          fi
+
+          ./linuxdeploy-x86_64.AppImage \
+            --appdir AppDir \
+            -e AppDir/usr/bin/hummingbird \
+            -d AppDir/hummingbird.desktop \
+            -i AppDir/hummingbird.png \
+            --output appimage
+
+          OUT="$(ls -1 *.AppImage | head -n 1)"
+          mv "$OUT" "dist/Hummingbird-${VER}-linux-x86_64.AppImage"
+
+          echo "Created dist/Hummingbird-${VER}-linux-x86_64.AppImage"
+          file AppDir/usr/bin/hummingbird
+          ldd AppDir/usr/bin/hummingbird || true
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: linux-appimage
+          path: dist/*.AppImage
+
+  github_release:
+    runs-on: ubuntu-latest
+    name: Publish GitHub Release
+    needs: [windows_zip, linux_appimage]
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: "${{ github.ref_name }}"
+          tag_name: "${{ github.ref_name }}"
+          generate_release_notes: true
+          files: |
+            dist/**/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,8 @@ jobs:
 
       - name: Test (Release)
         run: ctest --preset ninja-multi-vcpkg -C Release --output-on-failure
+        env:
+          HB_RUN_SMOKE_TEST: "1"
 
       - name: Stage + Zip
         shell: pwsh
@@ -129,6 +131,8 @@ jobs:
 
       - name: Test (Release, headless)
         run: xvfb-run -a ctest --preset ninja-multi-vcpkg -C Release --output-on-failure
+        env:
+          HB_RUN_SMOKE_TEST: "1"
 
       - name: Build AppImage
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,6 +214,16 @@ jobs:
     needs: [windows_zip, linux_appimage]
 
     steps:
+      - name: Determine prerelease flag
+        shell: bash
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          if [[ "$tag" =~ (a|b|rc)[0-9]+$ ]]; then
+            echo "HB_PRERELEASE=true" >> "$GITHUB_ENV"
+          else
+            echo "HB_PRERELEASE=false" >> "$GITHUB_ENV"
+          fi
+
       - uses: actions/download-artifact@v4
         with:
           path: dist
@@ -224,5 +234,6 @@ jobs:
           name: "${{ github.ref_name }}"
           tag_name: "${{ github.ref_name }}"
           generate_release_notes: true
+          prerelease: ${{ env.HB_PRERELEASE == 'true' }}
           files: |
             dist/**/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ target_include_directories(Html
     PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
+target_link_libraries(Html PUBLIC Core)
 
 # --- Layout Library ---
 add_library(Layout STATIC
@@ -101,7 +102,7 @@ target_include_directories(Layout
     PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
-target_link_libraries(Layout PUBLIC blend2d::blend2d Style)
+target_link_libraries(Layout PUBLIC Core Style)
 
 # --- Renderer Library ---
 add_library(Renderer STATIC

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing
+
+Thanks for your interest in Hummingbird.
+
+This is an early, fast-moving prototype and I may not be able to review or merge external PRs quickly. If you want to help, the best first step is to open an issue describing what you want to work on, or reach out to the author directly.
+
+## What I’m looking for
+
+- Bug reports with repro steps (and screenshots/logs when possible)
+- Small, focused fixes with tests
+- Documentation improvements
+
+For larger changes (new subsystems, big refactors, new dependencies), please ask first.
+
+## Development workflow
+
+- Formatting: keep code `clang-format`’d (CI checks formatting under `src/`).
+- Build/test locally:
+  - Configure/build: `cmake --preset ninja-multi-vcpkg && cmake --build --preset ninja-multi-vcpkg --config Release`
+  - Tests: `ctest --preset ninja-multi-vcpkg -C Release --output-on-failure`
+  - Optional smoke test (opens a window): `HB_RUN_SMOKE_TEST=1 ctest --preset ninja-multi-vcpkg -C Release --output-on-failure`
+
+## Licensing
+
+By contributing, you agree that your contributions are licensed under the project’s license (Apache-2.0, see `LICENSE`).
+
+If you add or bundle third-party code/assets, include the relevant license text in the repository (and keep it close to the asset when possible, e.g. `assets/.../LICENSE.txt`).

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,201 @@
-MIT License
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2025 MichalPC
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT of OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,6 @@
+Hummingbird Browser Engine
+
+Copyright 2025 Michal "Dvorka" Dvorak
+
+This product includes third-party components. See `assets/fonts/Roboto-LICENSE.txt`
+and the license notices packaged under `licenses/` in release artifacts.

--- a/README.md
+++ b/README.md
@@ -1,50 +1,123 @@
 # Hummingbird Browser Engine
 
-Hummingbird is an experimental, lightweight browser engine being built from scratch in C++20. The goal of this project is educational, aiming to explore the inner workings of a browser, from HTML parsing and DOM creation to rendering and layout.
+Hummingbird is an experimental browser engine built from scratch in C++20 (HTML → DOM → layout → paint). It’s primarily an educational project.
 
-## Milestones
+## Status / expectations
 
--   [x] **Epic 0: The Engine Foundation** — windowing, graphics context, arena allocator, and stubbed networking in place.
--   [!] **Epic 1: HTML → DOM → Render (in progress)** — tokenizer, DOM builder, UA defaults for lists/links/headings/code, block + inline layout, render tree + painter. Next up: render-tree construction refinements and inline text flow improvements (Epic 1.4+).
--   [ ] **Epic 2: CSS Parser / Cascade** — real stylesheet inputs and broader selector support.
--   [ ] **Epic 3: DOM & Layout Tree** — richer layout behaviors and block/inline refinements.
--   [ ] **Epic 4: Render Tree & Painting** — full paint traversal and debugging overlays.
+This is an early prototype:
 
-## Getting Started
+- It is **not a secure browser** (no sandboxing, no site isolation, no permissions model).
+- There is **no JavaScript**.
+- HTML/CSS support is partial and changes frequently.
+
+## What works today (high level)
+
+- HTML tokenizer + parser building a DOM tree.
+- CSS parsing for a subset of selectors/properties, including `<style>` blocks.
+- Basic block + inline layout (with ongoing work on inline flow).
+- Painting via Blend2D into an SDL2 window.
+- Fetching HTML via libcurl, plus a deterministic built-in demo page at `https://example.dev`.
+
+## Getting started (prebuilt releases)
+
+Releases are published on GitHub as:
+
+- **Linux AppImage**: `Hummingbird-<version>-linux-x86_64.AppImage`
+- **Windows portable zip**: `Hummingbird-<version>-win64.zip`
+
+### Linux (AppImage)
+
+1. Download the `.AppImage` from GitHub Releases.
+2. Run it:
+
+   ```bash
+   chmod +x ./Hummingbird-*-linux-x86_64.AppImage
+   ./Hummingbird-*-linux-x86_64.AppImage
+   ```
+
+If your distro doesn’t support running AppImages (often missing `fuse2`), you can extract and run:
+
+```bash
+./Hummingbird-*-linux-x86_64.AppImage --appimage-extract
+cd squashfs-root
+HB_ASSET_ROOT="$PWD/usr/share/hummingbird" ./usr/bin/hummingbird
+```
+
+### Windows (zip)
+
+1. Download the `.zip` from GitHub Releases and extract it.
+2. Run `hummingbird.exe` from the extracted folder.
+
+Keep the `assets/` folder next to the executable (fonts, UA stylesheet, etc).
+
+## Building from source
+
+This project uses a `vcpkg.json` manifest; dependencies are installed by vcpkg during CMake configure.
 
 ### Prerequisites
 
--   A C++20 compatible compiler (e.g., MSVC, GCC, Clang).
--   [CMake](https://cmake.org/download/) (version 3.20 or later).
--   [vcpkg](https://github.com/microsoft/vcpkg) for dependency management. Ensure you have the `VCPKG_ROOT` environment variable set.
+- C++20 compiler (MSVC / Clang / GCC)
+- CMake ≥ 3.20
+- Ninja
+- vcpkg with `VCPKG_ROOT` set
 
-### Building
+Linux packages (Ubuntu/Debian) roughly matching CI:
 
-This project uses a `vcpkg.json` manifest to declare its dependencies. They will be installed automatically by CMake.
+```bash
+sudo apt-get update
+sudo apt-get install -y \
+  build-essential ninja-build \
+  libx11-dev libxft-dev libxext-dev \
+  autoconf autoconf-archive automake libtool libltdl-dev
+```
 
-1.  **Clone the repository:**
-    ```bash
-    git clone <repository-url>
-    cd hummingbird
-    ```
+If you want to run tests headlessly, also install `xvfb` (CI uses it).
 
-2.  **Configure CMake:**
-    Run the following command from the root of the project. This will configure the project and download the dependencies into a `vcpkg_installed` directory.
-    ```bash
-    cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%/scripts/buildsystems/vcpkg.cmake
-    ```
-    *(On Linux/macOS, use `$VCPKG_ROOT` instead of `%VCPKG_ROOT%`)*
+### Build steps (using presets)
 
-3.  **Build the project:**
-    ```bash
-    cmake --build build
-    ```
+```bash
+export VCPKG_ROOT="$HOME/path/to/vcpkg"
+cmake --preset ninja-multi-vcpkg
+cmake --build --preset ninja-multi-vcpkg --config Release
+```
 
-4.  **Run the application:**
-    The executable will be located in the `build/Debug` directory.
-    ```bash
-    ./build/Debug/Hummingbird
-    ```
+Run:
+
+```bash
+./build/Release/Hummingbird
+```
+
+### Tests
+
+```bash
+ctest --preset ninja-multi-vcpkg -C Release --output-on-failure
+```
+
+The smoke test that opens a window is guarded; enable it with:
+
+```bash
+HB_RUN_SMOKE_TEST=1 ctest --preset ninja-multi-vcpkg -C Release --output-on-failure
+```
+
+## Usage / controls
+
+- `Ctrl+L`: focus URL bar
+- `Enter`: navigate
+- `Esc`: unfocus URL bar
+- Mouse wheel: scroll
+- `F1`: toggle debug outlines
+
+Startup defaults to `https://example.dev` (a built-in demo page). Loading arbitrary sites is best-effort and incomplete.
+
+## License
+
+Hummingbird is licensed under the Apache License 2.0 (see `LICENSE` and `NOTICE`).
+
+This repository also contains third-party components. See `THIRD_PARTY_NOTICES.md`.
+
+## Contributing
+
+See `CONTRIBUTING.md`.
 
 ## Architecture
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -18,11 +18,11 @@ Hummingbird uses vcpkg to fetch/build third-party libraries declared in `vcpkg.j
 
 When building from source with vcpkg, vcpkg installs per-port license texts at:
 
-`vcpkg_installed/**/share/<port>/copyright`
+`**/vcpkg_installed/**/share/<port>/copyright` (often under `build/vcpkg_installed/...` when using the provided CMake preset)
 
 Release artifacts bundle these (best-effort) under:
 
-- Windows zip: `licenses/vcpkg/` (or `licenses/vcpkg-<port>.txt`)
+- Windows zip: `licenses/vcpkg/*.txt`
 - Linux AppImage: `usr/share/hummingbird/licenses/vcpkg/*.txt`
 
 ## Build-time tools (not bundled)

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,30 @@
+# Third-party notices
+
+This document lists third-party components used by Hummingbird and where their license texts are stored.
+
+## Bundled in this repository
+
+- Roboto fonts (`assets/fonts/Roboto-*.ttf`) — Apache License 2.0  
+  License text: `assets/fonts/Roboto-LICENSE.txt`
+
+## Dependencies (via vcpkg)
+
+Hummingbird uses vcpkg to fetch/build third-party libraries declared in `vcpkg.json`.
+
+- SDL2
+- Blend2D
+- libcurl
+- GoogleTest (tests only)
+
+When building from source with vcpkg, vcpkg installs per-port license texts at:
+
+`vcpkg_installed/**/share/<port>/copyright`
+
+Release artifacts bundle these (best-effort) under:
+
+- Windows zip: `licenses/vcpkg/` (or `licenses/vcpkg-<port>.txt`)
+- Linux AppImage: `usr/share/hummingbird/licenses/vcpkg/*.txt`
+
+## Build-time tools (not bundled)
+
+CI/release packaging uses tools such as CMake, Ninja, and (for Linux AppImage packaging) linuxdeploy. These are not shipped inside the repository as redistributable components.

--- a/assets/fonts/Roboto-LICENSE.txt
+++ b/assets/fonts/Roboto-LICENSE.txt
@@ -1,0 +1,194 @@
+Roboto font files (Roboto-Regular.ttf, Roboto-Italic.ttf, Roboto-Bold.ttf, Roboto-BoldItalic.ttf) are distributed under the Apache License, Version 2.0.
+
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction,
+and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by
+the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all
+other entities that control, are controlled by, or are under common
+control with that entity. For the purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the
+direction or management of such entity, whether by contract or
+otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity
+exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation
+source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical
+transformation or translation of a Source form, including but
+not limited to compiled object code, generated documentation,
+and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or
+Object form, made available under the License, as indicated by a
+copyright notice that is included in or attached to the work
+(an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object
+form, that is based on (or derived from) the Work and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship. For the purposes
+of this License, Derivative Works shall not include works that remain
+separable from, or merely link (or bind by name) to the interfaces of,
+the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including
+the original version of the Work and any modifications or additions
+to that Work or Derivative Works thereof, that is intentionally
+submitted to Licensor for inclusion in the Work by the copyright owner
+or by an individual or Legal Entity authorized to submit on behalf of
+the copyright owner. For the purposes of this definition, "submitted"
+means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems,
+and issue tracking systems that are managed by, or on behalf of, the
+Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise
+designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity
+on behalf of whom a Contribution has been received by Licensor and
+subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the
+Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made,
+use, offer to sell, sell, import, and otherwise transfer the Work,
+where such license applies only to those patent claims licensable
+by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s)
+with the Work to which such Contribution(s) was submitted. If You
+institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work
+or a Contribution incorporated within the Work constitutes direct
+or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate
+as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+Work or Derivative Works thereof in any medium, with or without
+modifications, and in Source or Object form, provided that You
+meet the following conditions:
+
+(a) You must give any other recipients of the Work or
+    Derivative Works a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices
+    stating that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works
+    that You distribute, all copyright, patent, trademark, and
+    attribution notices from the Source form of the Work,
+    excluding those notices that do not pertain to any part of
+    the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its
+    distribution, then any Derivative Works that You distribute must
+    include a readable copy of the attribution notices contained
+    within such NOTICE file, excluding those notices that do not
+    pertain to any part of the Derivative Works, in at least one
+    of the following places: within a NOTICE text file distributed
+    as part of the Derivative Works; within the Source form or
+    documentation, if provided along with the Derivative Works; or,
+    within a display generated by the Derivative Works, if and
+    wherever such third-party notices normally appear. The contents
+    of the NOTICE file are for informational purposes only and
+    do not modify the License. You may add Your own attribution
+    notices within Derivative Works that You distribute, alongside
+    or as an addendum to the NOTICE text from the Work, provided
+    that such additional attribution notices cannot be construed
+    as modifying the License.
+
+You may add Your own copyright statement to Your modifications and
+may provide additional or different license terms and conditions
+for use, reproduction, or distribution of Your modifications, or
+for any such Derivative Works as a whole, provided Your use,
+reproduction, and distribution of the Work otherwise complies with
+the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+any Contribution intentionally submitted for inclusion in the Work
+by You to the Licensor shall be under the terms and conditions of
+this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify
+the terms of any separate license agreement you may have executed
+with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+names, trademarks, service marks, or product names of the Licensor,
+except as required for reasonable and customary use in describing the
+origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+agreed to in writing, Licensor provides the Work (and each
+Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied, including, without limitation, any warranties or conditions
+of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any
+risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+whether in tort (including negligence), contract, or otherwise,
+unless required by applicable law (such as deliberate and grossly
+negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special,
+incidental, or consequential damages of any character arising as a
+result of this License or out of the use or inability to use the
+Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all
+other commercial damages or losses), even if such Contributor
+has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+the Work or Derivative Works thereof, You may choose to offer,
+and charge a fee for, acceptance of support, warranty, indemnity,
+or other liability obligations and/or rights consistent with this
+License. However, in accepting such obligations, You may act only
+on Your own behalf and on Your sole responsibility, not on behalf
+of any other Contributor, and only if You agree to indemnify,
+defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason
+of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/doc/milestones/milestone2.md
+++ b/doc/milestones/milestone2.md
@@ -362,9 +362,9 @@ Before you write a single line of CSS parsing code, the codebase must pass this 
 
 These sites are perfect "Golden Masters" for Milestone 2 because they rely heavily on the **Cascade**, **Box Model**, and **Typography** without needing JavaScript.
 
-1. **[BetterMotherfuckingWebsite.com](http://bettermotherfuckingwebsite.com/)**
-* **Why:** This is the direct sequel to your M1 test case. It adds basic CSS (margins, line-height, color, max-width) to the original.
-* **Test Value:** Verifies that your engine can override the "User Agent" styles you wrote in M1.
+1. **[IANA Example Domains](https://www.iana.org/help/example-domains)**
+* **Why:** A clean, stable HTML page that’s safe to link publicly.
+* **Test Value:** Basic typography + link styling without relying on scripting.
 
 
 2. **[CSS Zen Garden (The Sample HTML)](http://www.csszengarden.com/)**

--- a/src/app/BrowserApp.h
+++ b/src/app/BrowserApp.h
@@ -92,7 +92,7 @@ private:
     Hummingbird::Renderer::Painter painter_;
 
     // UI state
-    std::string url_bar_text_ = "http://bettermotherfuckingwebsite.com/";
+    std::string url_bar_text_ = "https://example.dev";
     std::string requested_url_ = url_bar_text_;
     bool url_bar_active_ = true;
     bool debug_outlines_ = false;

--- a/src/core/utils/AssetPath.cpp
+++ b/src/core/utils/AssetPath.cpp
@@ -1,5 +1,6 @@
 #include "core/utils/AssetPath.h"
 
+#include <cstdlib>
 #include <filesystem>
 
 namespace Hummingbird {
@@ -8,6 +9,26 @@ std::filesystem::path resolve_asset_path(std::string_view relative_path) {
     std::filesystem::path rel(relative_path);
     if (rel.is_absolute()) {
         return rel;
+    }
+
+    if (const char* asset_root = std::getenv("HB_ASSET_ROOT"); asset_root && *asset_root) {
+        std::filesystem::path base(asset_root);
+        auto candidate = base / rel;
+        if (std::filesystem::exists(candidate)) {
+            return candidate.lexically_normal();
+        }
+    }
+
+    if (const char* appdir = std::getenv("APPDIR"); appdir && *appdir) {
+        std::filesystem::path base(appdir);
+        auto candidate = base / "usr/share/hummingbird" / rel;
+        if (std::filesystem::exists(candidate)) {
+            return candidate.lexically_normal();
+        }
+        candidate = base / rel;
+        if (std::filesystem::exists(candidate)) {
+            return candidate.lexically_normal();
+        }
     }
 
     std::filesystem::path current = std::filesystem::current_path();

--- a/src/layout/TextBox.cpp
+++ b/src/layout/TextBox.cpp
@@ -1,6 +1,7 @@
 #include "layout/TextBox.h"
 
 #include <algorithm>
+#include <atomic>
 #include <cctype>
 
 #include "core/platform_api/IGraphicsContext.h"
@@ -228,8 +229,13 @@ void TextBox::layout(IGraphicsContext& context, const Rect& bounds) {
     TextStyle text_style = build_text_style(style);
     text_style.font_size = font_size;
 
-    // TODO: choose real monospace fonts when available.
-    HB_LOG_WARN("[layout] Not implemented: real monospace font selection");
+    if (text_style.monospace) {
+        // TODO: choose real monospace fonts when available.
+        static std::atomic<bool> warned{false};
+        if (!warned.exchange(true, std::memory_order_relaxed)) {
+            HB_LOG_WARN("[layout] Not implemented: real monospace font selection");
+        }
+    }
     float line_height = measure_text_block(context, m_rendered_text, text_style, m_last_metrics);
     m_line_height = line_height;
 

--- a/src/platform/SDLWindow.cpp
+++ b/src/platform/SDLWindow.cpp
@@ -25,6 +25,10 @@ void SDLWindow::open() {
 
     m_renderer = SDL_CreateRenderer(m_window, -1, SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC);
     if (m_renderer == nullptr) {
+        HB_LOG_WARN("[platform] SDL_CreateRenderer (accelerated) failed: " << SDL_GetError());
+        m_renderer = SDL_CreateRenderer(m_window, -1, SDL_RENDERER_SOFTWARE);
+    }
+    if (m_renderer == nullptr) {
         HB_LOG_ERROR("[platform] SDL_CreateRenderer failed: " << SDL_GetError());
         close();
         return;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,6 +3,9 @@ find_package(GTest REQUIRED)
 
 # Create the test executable
 add_executable(HummingbirdTests
+    app/SmokeMain.test.cpp
+    ../src/app/BrowserApp.cpp
+    ../src/app/BrowserApp.h
     core/ArenaAllocator.test.cpp
     core/AssetPath.test.cpp
     core/Timing.test.cpp

--- a/tests/app/SmokeMain.test.cpp
+++ b/tests/app/SmokeMain.test.cpp
@@ -1,11 +1,11 @@
-#include <chrono>
+#include <gtest/gtest.h>
+
 #include <cctype>
+#include <chrono>
 #include <cstdlib>
 #include <memory>
 #include <string_view>
 #include <utility>
-
-#include <gtest/gtest.h>
 
 #include "app/BrowserApp.h"
 #include "core/platform_api/WindowFactory.h"

--- a/tests/app/SmokeMain.test.cpp
+++ b/tests/app/SmokeMain.test.cpp
@@ -1,0 +1,59 @@
+#include <chrono>
+#include <cctype>
+#include <cstdlib>
+#include <memory>
+#include <string_view>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+#include "app/BrowserApp.h"
+#include "core/platform_api/WindowFactory.h"
+
+namespace {
+bool is_truthy_env(const char* value) {
+    if (!value) return false;
+    std::string_view view(value);
+    auto equals = [&](std::string_view needle) {
+        if (view.size() != needle.size()) return false;
+        for (size_t i = 0; i < view.size(); ++i) {
+            char a = static_cast<char>(std::tolower(static_cast<unsigned char>(view[i])));
+            char b = static_cast<char>(std::tolower(static_cast<unsigned char>(needle[i])));
+            if (a != b) return false;
+        }
+        return true;
+    };
+    return equals("1") || equals("true") || equals("yes") || equals("on");
+}
+}  // namespace
+
+TEST(SmokeMainTest, StartsAndTicks) {
+    if (!is_truthy_env(std::getenv("HB_RUN_SMOKE_TEST"))) {
+        GTEST_SKIP() << "Set HB_RUN_SMOKE_TEST=1 to enable the smoke test.";
+    }
+
+    auto window = create_window();
+    ASSERT_NE(window, nullptr);
+    window->open();
+    ASSERT_TRUE(window->is_open());
+
+    auto gfx = window->get_graphics_context();
+    ASSERT_NE(gfx, nullptr);
+
+    BrowserApp app(std::move(window));
+    app.start();
+
+    using clock = std::chrono::steady_clock;
+    const auto deadline = clock::now() + std::chrono::seconds(5);
+
+    int frames = 0;
+    while (clock::now() < deadline) {
+        if (!app.tick()) break;
+        ++frames;
+        if (frames >= 10) break;
+    }
+
+    app.shutdown();
+
+    EXPECT_GT(frames, 0);
+}

--- a/tests/core/ArenaAllocator.test.cpp
+++ b/tests/core/ArenaAllocator.test.cpp
@@ -1,5 +1,6 @@
-#include <gtest/gtest.h>
 #include "core/ArenaAllocator.h"
+
+#include <gtest/gtest.h>
 
 TEST(ArenaAllocatorTest, SimpleAllocation) {
     ArenaAllocator allocator(1024);
@@ -28,7 +29,7 @@ TEST(ArenaAllocatorTest, Reset) {
 TEST(ArenaAllocatorTest, ZeroAllocation) {
     ArenaAllocator allocator(1024);
     void* ptr = allocator.allocate(0);
-    ASSERT_NE(ptr, nullptr); // Allocating 0 bytes should still return a valid pointer
+    ASSERT_NE(ptr, nullptr);  // Allocating 0 bytes should still return a valid pointer
 }
 
 TEST(ArenaAllocatorTest, RespectsAlignment) {

--- a/tests/core/AssetPath.test.cpp
+++ b/tests/core/AssetPath.test.cpp
@@ -2,9 +2,71 @@
 
 #include <gtest/gtest.h>
 
+#include <cstdlib>
+#include <fstream>
 #include <filesystem>
+#include <optional>
+#include <string>
+
+namespace {
+void set_env_var(const char* name, const std::string& value) {
+#ifdef _WIN32
+    _putenv_s(name, value.c_str());
+#else
+    setenv(name, value.c_str(), 1);
+#endif
+}
+
+void unset_env_var(const char* name) {
+#ifdef _WIN32
+    _putenv_s(name, "");
+#else
+    unsetenv(name);
+#endif
+}
+
+class EnvVarGuard {
+public:
+    EnvVarGuard(const char* name, const std::string& value) : name_(name) {
+        if (const char* current = std::getenv(name_)) {
+            previous_ = current;
+        }
+        set_env_var(name_, value);
+    }
+
+    ~EnvVarGuard() {
+        if (previous_) {
+            set_env_var(name_, *previous_);
+        } else {
+            unset_env_var(name_);
+        }
+    }
+
+private:
+    const char* name_;
+    std::optional<std::string> previous_;
+};
+}  // namespace
 
 TEST(AssetPathTest, ResolvesFontFromRepoRoot) {
     auto path = Hummingbird::resolve_asset_path("assets/fonts/Roboto-Regular.ttf");
     EXPECT_TRUE(std::filesystem::exists(path));
+}
+
+TEST(AssetPathTest, RespectsAssetRootEnv) {
+    std::filesystem::path root = std::filesystem::temp_directory_path() / "hummingbird-asset-test";
+    std::error_code ec;
+    std::filesystem::remove_all(root, ec);
+    std::filesystem::create_directories(root / "assets/fonts");
+
+    std::filesystem::path font_path = root / "assets/fonts/Dummy.ttf";
+    std::ofstream(font_path.string()) << "dummy";
+
+    EnvVarGuard guard("HB_ASSET_ROOT", root.string());
+
+    auto resolved = Hummingbird::resolve_asset_path("assets/fonts/Dummy.ttf");
+    EXPECT_TRUE(std::filesystem::exists(resolved));
+    EXPECT_TRUE(std::filesystem::equivalent(resolved, font_path));
+
+    std::filesystem::remove_all(root, ec);
 }

--- a/tests/core/AssetPath.test.cpp
+++ b/tests/core/AssetPath.test.cpp
@@ -3,8 +3,8 @@
 #include <gtest/gtest.h>
 
 #include <cstdlib>
-#include <fstream>
 #include <filesystem>
+#include <fstream>
 #include <optional>
 #include <string>
 

--- a/tests/layout/BlockBox.test.cpp
+++ b/tests/layout/BlockBox.test.cpp
@@ -1,5 +1,4 @@
 #include "layout/BlockBox.h"
-#include "layout/TextBox.h"
 
 #include <gtest/gtest.h>
 
@@ -9,6 +8,7 @@
 #include "core/dom/Element.h"
 #include "core/dom/Text.h"
 #include "html/HtmlAttributeNames.h"
+#include "layout/TextBox.h"
 #include "layout/TreeBuilder.h"
 
 using namespace Hummingbird::Layout;
@@ -90,8 +90,7 @@ TEST(BlockBoxLayoutTest, InlineBlockShrinksToContent) {
     span->append_child(std::move(text));
 
     auto inline_block = InlineBlockBox::create(span.get());
-    inline_block->append_child(TextBox::create(
-        dynamic_cast<Text*>(span->get_children()[0].get())));
+    inline_block->append_child(TextBox::create(dynamic_cast<Text*>(span->get_children()[0].get())));
 
     TestGraphicsContext context;
     Rect bounds{0, 0, 300, 0};

--- a/tests/layout/InlineLineBuilder.test.cpp
+++ b/tests/layout/InlineLineBuilder.test.cpp
@@ -1,6 +1,6 @@
-#include <gtest/gtest.h>
-
 #include "layout/InlineLineBuilder.h"
+
+#include <gtest/gtest.h>
 
 using Hummingbird::Layout::InlineLineBuilder;
 using Hummingbird::Layout::InlineRun;

--- a/tests/layout/RenderControl.test.cpp
+++ b/tests/layout/RenderControl.test.cpp
@@ -1,11 +1,11 @@
 #include <gtest/gtest.h>
 
+#include "TestGraphicsContext.h"
 #include "core/ArenaAllocator.h"
 #include "core/dom/DomFactory.h"
 #include "core/dom/Element.h"
 #include "layout/RenderBreak.h"
 #include "layout/RenderRule.h"
-#include "TestGraphicsContext.h"
 
 using namespace Hummingbird::Layout;
 using namespace Hummingbird::DOM;

--- a/tests/layout/TextBox.test.cpp
+++ b/tests/layout/TextBox.test.cpp
@@ -1,12 +1,14 @@
+#include "layout/TextBox.h"
+
 #include <gtest/gtest.h>
 
 #include <string>
-#include "layout/TextBox.h"
+
+#include "TestGraphicsContext.h"
 #include "core/ArenaAllocator.h"
 #include "core/dom/DomFactory.h"
 #include "core/dom/Text.h"
 #include "style/ComputedStyle.h"
-#include "TestGraphicsContext.h"
 
 class FontCaptureContext : public IGraphicsContext {
 public:

--- a/tests/network/CurlNetwork.test.cpp
+++ b/tests/network/CurlNetwork.test.cpp
@@ -1,6 +1,6 @@
-#include <gtest/gtest.h>
-
 #include "platform/CurlNetwork.h"
+
+#include <gtest/gtest.h>
 
 TEST(CurlNetworkTest, AcceptEncodingIsEmptyForAutoDecompression) {
     EXPECT_STREQ(CurlNetwork::accept_encoding(), "");

--- a/tests/network/NetworkFactory.test.cpp
+++ b/tests/network/NetworkFactory.test.cpp
@@ -1,6 +1,6 @@
-#include <gtest/gtest.h>
-
 #include "core/platform_api/NetworkFactory.h"
+
+#include <gtest/gtest.h>
 
 TEST(NetworkFactoryTest, CreatesBackends) {
     auto curl = create_network(NetworkBackend::Curl);

--- a/tests/network/StubNetwork.test.cpp
+++ b/tests/network/StubNetwork.test.cpp
@@ -1,5 +1,7 @@
-#include <gtest/gtest.h>
 #include "platform/StubNetwork.h"
+
+#include <gtest/gtest.h>
+
 #include <future>
 
 TEST(StubNetworkTest, ReturnsExampleBody) {
@@ -16,7 +18,8 @@ TEST(StubNetworkTest, ReturnsExampleBody) {
     EXPECT_NE(body.find(".hidden { display: none; }"), std::string::npos);
     EXPECT_NE(body.find(".boxed { border-width: 20px; border-style: solid; border-color: #cc0000; padding: 4px; }"),
               std::string::npos);
-    EXPECT_NE(body.find(".inline-block { display: inline-block; border-width: 1px; border-style: solid; border-color: #008000; padding: 2px; }"),
+    EXPECT_NE(body.find(".inline-block { display: inline-block; border-width: 1px; border-style: solid; border-color: "
+                        "#008000; padding: 2px; }"),
               std::string::npos);
     EXPECT_NE(body.find(".external-demo { color: #cc0000; }"), std::string::npos);
     EXPECT_NE(body.find("class=\"boxed\""), std::string::npos);

--- a/tests/platform/ResourceProvider.test.cpp
+++ b/tests/platform/ResourceProvider.test.cpp
@@ -1,6 +1,6 @@
-#include "core/platform_api/ResourceProviderFactory.h"
-
 #include <gtest/gtest.h>
+
+#include "core/platform_api/ResourceProviderFactory.h"
 
 TEST(ResourceProviderTest, LoadsTextFromAssets) {
     auto provider = create_resource_provider();

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "hummingbird",
-  "version-string": "0.1.0",
+  "version-string": "0.2.1a1",
   "builtin-baseline": "00807e89724847a866033a2f042c38fafae3c534",
   "dependencies": [
     "sdl2",


### PR DESCRIPTION
This branch adds a tag-driven GitHub Actions release workflow that builds and tests Hummingbird, then publishes portable artifacts:

- Linux AppImage + Windows zip packaging (includes assets/ and runtime files)
- Runs ctest in Release; enables the windowed smoke test via HB_RUN_SMOKE_TEST=1
- Marks GitHub Releases as prereleases based on tag suffix (a, b, rc) 

Release/legal polish included:
- Switch project license from MIT → Apache-2.0 (adds NOTICE)
- Add THIRD_PARTY_NOTICES.md and Roboto font license text (Roboto-LICENSE.txt)
- Bundle vcpkg port license notices into release artifacts (best-effort)

Runtime/build quality fixes along the way:
- More robust asset resolution for AppImage and custom installs (APPDIR / HB_ASSET_ROOT)
- SDL renderer fallback to software for headless environments
- Minor CMake/test/pre-commit cleanup to match the new workflow