### PR TITLE
ci: skip CI for docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,18 @@ name: CI
 on:
   push:
     branches: [ master ]
+    paths-ignore:
+      - "doc/**"
+      - "**.md"
+      - "LICENSE"
+      - "NOTICE"
   pull_request:
     branches: [ master ]
+    paths-ignore:
+      - "doc/**"
+      - "**.md"
+      - "LICENSE"
+      - "NOTICE"
 
 jobs:
   # JOB 1: Code Formatting Check


### PR DESCRIPTION
Docs-only pushes/PRs (anything touching only `doc/**`, `**.md`, `LICENSE`, or `NOTICE`) no longer trigger the build pipeline, per `paths-ignore` on both triggers.

Notes:
- The release workflow is tag-triggered and needed no change.
- GitHub's native `[skip ci]` commit-message tag also remains available for one-off pushes.
- Caveat: if branch protection ever requires the build status check, docs-only PRs would show it as "expected" forever — at that point switch to the paths-filter-job pattern instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)