### PR TITLE
docs: roadmap compatibility ladder + relicense to AGPL-3.0-or-later

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,6 @@ For larger changes (new subsystems, big refactors, new dependencies), please ask
 
 ## Licensing
 
-By contributing, you agree that your contributions are licensed under the project’s license (Apache-2.0, see `LICENSE`).
+By contributing, you agree that your contributions are licensed under the project’s license (AGPL-3.0-or-later with an app-store additional permission, see `LICENSE`).
 
 If you add or bundle third-party code/assets, include the relevant license text in the repository (and keep it close to the asset when possible, e.g. `assets/.../LICENSE.txt`).

--- a/LICENSE
+++ b/LICENSE
@@ -1,201 +1,697 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+Hummingbird Browser Engine
+Copyright (C) 2025-2026 Michal "Dvorka" Dvořák
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-   1. Definitions.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
+================================================================================
 
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
+ADDITIONAL PERMISSION UNDER GNU AGPL VERSION 3 SECTION 7
 
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
+As an additional permission under section 7, you are allowed to distribute
+the software through an app store, even if that store has restrictive terms
+and conditions that are incompatible with the AGPL, provided that the source
+is also available under the AGPL with or without this permission through a
+channel without those restrictive terms and conditions.
 
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
+================================================================================
 
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
+The full text of the GNU Affero General Public License version 3 follows.
+You can also obtain it at <https://www.gnu.org/licenses/agpl-3.0.txt>.
 
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
+--- BEGIN GNU AFFERO GENERAL PUBLIC LICENSE VERSION 3 ---
 
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
 
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
+                            Preamble
 
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
 
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
 
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
 
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
 
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
 
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
 
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
 
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
+  The precise terms and conditions for copying, distribution and
+modification follow.
 
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
+                       TERMS AND CONDITIONS
 
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
+  0. Definitions.
 
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
+  "This License" refers to version 3 of the GNU Affero General Public License.
 
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
 
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
 
-   END OF TERMS AND CONDITIONS
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
 
-   APPENDIX: How to apply the Apache License to your work.
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
 
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
 
-   Copyright [yyyy] [name of copyright owner]
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
 
-       http://www.apache.org/licenses/LICENSE-2.0
+  1. Source Code.
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.
+
+
+--- END GNU AFFERO GENERAL PUBLIC LICENSE VERSION 3 ---

--- a/README.md
+++ b/README.md
@@ -256,7 +256,9 @@ HB_EXTENSIONS_ENABLE=dark-mode,my-ext ./build/Release/Hummingbird
 
 ## License
 
-Hummingbird is licensed under the Apache License 2.0 (see `LICENSE` and `NOTICE`).
+Hummingbird is licensed under the GNU Affero General Public License v3.0 or later
+(AGPL-3.0-or-later), with an additional permission under section 7 allowing app-store
+distribution (see `LICENSE`). Third-party attribution notices are listed in `NOTICE`.
 
 This repository also contains third-party components. See `THIRD_PARTY_NOTICES.md`.
 

--- a/doc/TODOs.md
+++ b/doc/TODOs.md
@@ -15,29 +15,27 @@ Milestone defined in `doc/milestones/milestone4.md` (stories moved there).
 - [x] **[M5 P1] T-LAYOUT-PERCENT-POS-1: Percentage Offsets For Positioned Elements**; Goal: make `top/right/bottom/left` `%` offsets behave consistently for positioned elements; Scope: positioning resolution path for absolute/relative offsets; Acceptance: `top:24%`-style layouts position as expected relative to containing block; Tests: positioning tests.
 - [x] **[M5 P1] T-FORM-HIT-1: Input Click Must Not Trigger Submit**; Goal: prevent accidental form submit when user clicks editable text fields; Scope: tighten form-submit hit semantics and add regression around DDG home form; Acceptance: clicking text input focuses caret and does not navigate; submit occurs only on submit control click or Enter; Tests: tab/document form interaction tests.
 
-## Milestone 5 (Layout/Polish)
+## Milestone 5 (The Architect: Tabs + Extensions)
 
 Milestone complete for `0.5.0` release scope. Archived in `doc/todo_archive/milestone5_done.md`.
-Deferred DDG parity follow-ups were moved to Milestone 6 backlog.
+Deferred DDG parity follow-ups were moved to Milestone 6.
 
-## Milestone 6+ (Big Rocks)
+## Milestone 6 (The Layouter)
 
-- [ ] **[M6 P1] T-ARCH-GUARD-1: Dependency Guardrails in CI**; Goal: prevent cycle regressions after refactors; Scope: add automated check for package-level cycles (using clang-uml artifacts or include-graph checks) and fail CI on new violations; Acceptance: CI reports cycle regressions deterministically; Tests: tooling/CI smoke.
-- [ ] **[M6 P1] T-ARCH-GUARD-2: Clang-UML Diagram Signal Cleanup**; Goal: keep architecture diagrams actionable; Scope: tune config/filters to reduce template/anonymous noise and emit stable focused diagrams for package and engine pipeline views; Acceptance: diagrams highlight project classes/modules with low noise and are documented in dev guide; Tests: docs/tooling.
-- [ ] **[M6 P1] T-HIST-1: Visited Link State**; Goal: track visited URLs and apply `vlink` colors appropriately; Scope: history store + style resolution; Acceptance: visited anchors render with `vlink`/`:visited` color; Tests: engine/style tests.
-- [ ] **[M6 P1] T-PERF-4: Offscreen Raster Cache + Layer Invalidation**; Goal: repaint only dirty regions; Scope: renderer + engine invalidation; Acceptance: cached layers reused across frames; Tests: renderer perf tests.
-- [ ] **[M6 P1] T-CACHE-1: Tab Resource Eviction + Rehydrate**; Goal: evict resources/render tree for background tabs and restore on focus; Scope: Tab + ResourceStore; Acceptance: inactive tabs drop memory and reload on activation; Tests: engine tests.
-- [ ] **[M6 P1] T-DOM-1: Infinite Scroll DOM Virtualization**; Goal: cap live DOM/resources for unbounded feeds; Scope: DOM/layout + resource eviction; Acceptance: long feeds do not grow memory unbounded and can rehydrate when revisiting content; Tests: engine perf tests.
-- [ ] **[M6 P1] T-DOM-2: DOM Budget Failure UX**; Goal: show a stable error page and recovery action when DOM budget is exceeded; Scope: DocumentPipeline + ResourceLoader; Acceptance: budget failure shows user-facing page instead of blank reset; Tests: engine tests.
-- [ ] **[M6 P1] T-PERF-5: Batch Resource Updates**; Goal: coalesce resource arrivals into fewer style/layout passes; Scope: ResourceLoader + DocumentPipeline; Acceptance: heavy pages avoid repeated full rebuilds; Tests: engine perf tests.
-- [ ] **[M8 P2] T-DOM-CUSTOM-1: Custom Elements Upgrade**; Goal: allow JS `customElements.define()` to upgrade dash-named tags and run lifecycle hooks; Scope: DOM + JS bindings; Acceptance: defined custom element runs constructor/connectedCallback and can attach shadow/DOM; Tests: DOM/JS integration tests.
-- [ ] **[M6 P1] T-DDG-CSS-CORE-2: DDG CSS Compatibility Carryover**; Goal: finish the remaining DDG visual-compatibility deltas deferred from Milestone 5; Scope: extend CSS/layout compatibility to close search/logo alignment and control-chrome gaps on DDG HTML; Acceptance: DDG homepage matches reference layout for centered logo/search block and no severe control overlap; Tests: DDG manual checklist (`doc/checklists/m5_ddg_css_core.md`) plus targeted regressions.
-- [ ] **[M6 P1] T-DDG-E2E-1: Real DDG HTML Snapshot Regression Harness**; Goal: validate DDG usability end-to-end against a realistic fixture; Scope: add pinned DDG HTML snapshot fixture, drive focus/type/submit/navigation flow in headless tab/app harness, and assert no overlap/regression around search controls; Acceptance: CI fails if DDG-like typing/submit flow regresses; Tests: engine/app integration tests.
-- [ ] **[M6 P1] T-LAYOUT-FLEX-1: Flexbox Layout MVP**; Goal: basic flex layout; Scope: layout engine; Acceptance: common flex rows/columns render; Tests: layout tests.
-- [ ] **[M6 P1] T-DDG-LAYOUT-1: Flex Alignment Coverage For Real Pages**; Goal: close major DDG homepage positioning gap; Scope: support `flex`, `flex-direction`, `flex-wrap`, `flex-basis`, `flex-shrink`, `align-items`, `justify-content`, `order` with enough fidelity for form/logo centering flows; Acceptance: DDG logo and search form center similarly to reference browser; Tests: layout regression fixture for DDG-like structure.
-- [ ] **[M6 P1] T-CSS-CLEAR-1: Float Clear Property**; Goal: prevent float/layout overlap in legacy page structures; Scope: parse/apply `clear` and integrate with block flow line placement; Acceptance: blocks that rely on `clear` no longer overlap preceding floated elements; Tests: block layout regressions.
-- [ ] **[M6 P1] T-CSS-BORDER-COMPAT-1: Border Longhands And Corner Radius Longhands**; Goal: remove visible control chrome mismatches on real forms; Scope: add `border-top/right/bottom/left-color`, `border-top-left/right/bottom-left/bottom-right-radius`, and vendor aliases (`-moz-`, `-webkit-`) mapped to standard properties; Acceptance: DDG search control corners/borders match expected shape without split seams; Tests: parser/style/paint regressions.
-- [ ] **[M6 P2] T-CSS-COMPAT-ALIAS-1: Vendor Prefix Alias Layer**; Goal: reduce noisy unsupported-property fallout for legacy CSS; Scope: alias common prefixed properties to supported canonical forms where behavior is equivalent (`-webkit-user-select`, `-moz-appearance`, `-webkit-tap-highlight-color`, etc.) and silently ignore purely cosmetic no-op aliases; Acceptance: warning noise drops on DDG-like pages without behavioral regressions; Tests: parser alias tests.
-- [ ] **[M6 P2] T-CSS-MISC-LEGACY-1: Legacy Property Compatibility Slice**; Goal: close remaining DDG visual deltas not covered by flex/border work; Scope: targeted support for `text-shadow`, `visibility`, `pointer-events`, and legacy `clip` usage required by DDG assets/icons; Acceptance: DDG search icon/control visuals and hit behavior align with reference browser; Tests: style/layout interaction regressions.
-- [ ] **[M6 P2] T-LAYOUT-GRID-1: Grid Layout MVP**; Goal: minimal CSS Grid support; Scope: layout engine; Acceptance: fixed-track grids render; Tests: layout tests.
-- [ ] **[M6 P2] T-ANIM-1: transition + transform (static)**; Goal: parse/apply transforms without timing engine; Scope: style + paint; Acceptance: transform affects paint matrix; Tests: renderer tests.
+Milestone defined in `doc/milestones/milestone6.md` (stories moved there).
+
+## Milestone 7 (The Programmable Document)
+
+Milestone defined in `doc/milestones/milestone7.md`.
+
+## Milestone 8 (The Session Keeper)
+
+Milestone defined in `doc/milestones/milestone8.md`.
+
+## Milestone 9 (The Fetcher)
+
+Draft defined in `doc/milestones/milestone9.md` — revalidate scope at kickoff.
+
+## Milestone 10+ (Later)
+
+- [ ] **[M12 P1] T-DOM-CUSTOM-1: Custom Elements Upgrade** (M12 Framework Gauntlet; required for YouTube/Polymer); Goal: allow JS `customElements.define()` to upgrade dash-named tags and run lifecycle hooks; Scope: DOM + JS bindings; Acceptance: defined custom element runs constructor/connectedCallback and can attach shadow/DOM; Tests: DOM/JS integration tests.

--- a/doc/milestones/milestone6.md
+++ b/doc/milestones/milestone6.md
@@ -1,0 +1,134 @@
+## Milestone 6 North Star Deliverable
+
+**Before (after Milestone 5):**
+
+* Browser has a working Browser OS layer: multi-tab, extensions, background scripts, CSS injection, Dark Mode.
+* DDG HTML mode is *usable* end-to-end (focus/type/submit/navigate), but the page does not *look* right:
+  * logo/search block is not centered (no flexbox),
+  * control chrome (borders, corner radii) diverges from reference browsers,
+  * legacy/vendor-prefixed CSS produces noise and visual gaps.
+* DDG regressions are guarded only by manual checking, not CI (note: the `doc/checklists/` files referenced by earlier TODOs were never committed — recreate the DDG checklist as part of this milestone).
+* Package-cycle hygiene from M5 refactors has no automated enforcement.
+
+**After (Milestone 6 done):**
+
+* **Flexbox v1** works with enough fidelity for real-page centering/alignment flows.
+* **DDG HTML homepage visually matches a reference browser** for the centered logo/search block, with no severe control overlap.
+* **Automated DDG regression harness in CI**: a pinned DDG HTML snapshot drives the focus/type/submit/navigate flow headlessly; CI fails on regression.
+* **Dependency guardrails in CI**: new package-level cycles fail the build.
+
+---
+
+## Non-Goals (keep the blast radius controlled)
+
+* No full flexbox spec coverage — only the property subset real target pages need (`flex`, `flex-direction`, `flex-wrap`, `flex-basis`, `flex-shrink`, `align-items`, `justify-content`, `order`).
+* No CSS Grid beyond an optional fixed-track MVP (P2, only if schedule allows).
+* No compositor / layer-tree / raster-thread work; perf items in this milestone are bounded hygiene, not architecture.
+* No animation timing engine (`transition`/`transform` parse-and-apply-static only, P2).
+* No new threading (DOM/layout/style stays main-thread deterministic).
+* No `position: fixed`/`sticky`, scroll containers, or stacking-context work — that "Layouter v2" slice stays in the roadmap for a later milestone (DDG HTML does not need it).
+
+---
+
+## Critical Path (what must land for the North Star)
+
+**Must-have**
+
+* **Flexbox MVP** (`T-LAYOUT-FLEX-1`) plus **real-page alignment coverage** (`T-DDG-LAYOUT-1`).
+* **Float `clear` support** (`T-CSS-CLEAR-1`) for legacy page structures.
+* **Border/radius longhands + vendor aliases** (`T-CSS-BORDER-COMPAT-1`) for control chrome.
+* **DDG CSS compatibility carryover** (`T-DDG-CSS-CORE-2`) — the deltas deferred from M5.
+* **DDG snapshot regression harness** (`T-DDG-E2E-1`) wired into CI.
+* **Dependency guardrails in CI** (`T-ARCH-GUARD-1`).
+
+**Nice-to-have (if schedule allows)**
+
+* Vendor prefix alias layer (`T-CSS-COMPAT-ALIAS-1`), legacy property slice (`T-CSS-MISC-LEGACY-1`).
+* Grid MVP (`T-LAYOUT-GRID-1`), static transition/transform (`T-ANIM-1`).
+* Visited link state (`T-HIST-1`), clang-uml diagram cleanup (`T-ARCH-GUARD-2`).
+
+**Perf/memory hygiene track (pull in only if real pages force it)**
+
+* Batch resource updates (`T-PERF-5`), offscreen raster cache (`T-PERF-4`), tab resource eviction (`T-CACHE-1`), DOM virtualization (`T-DOM-1`), DOM budget failure UX (`T-DOM-2`).
+
+---
+
+## Milestone 6 Done When
+
+Milestone 6 is complete when all items below are true:
+
+* Common flex rows/columns render correctly (layout tests pass for the supported property subset).
+* DDG HTML homepage shows the logo/search block centered like a reference browser, with no severe control overlap (manual DDG checklist passes — recreate it under `doc/checklists/` since the file referenced by earlier TODOs was never committed).
+* CI runs the DDG snapshot harness and fails on typing/submit/navigation or layout regression.
+* CI fails deterministically on new package-level dependency cycles.
+* No new forbidden dependency edges (Ports & Adapters intact).
+
+---
+
+## Stories
+
+### 6.1 - Flexbox & Layout Compatibility
+
+* **[M6 P1] T-LAYOUT-FLEX-1: Flexbox Layout MVP**; Goal: basic flex layout; Scope: layout engine; Acceptance: common flex rows/columns render; Tests: layout tests.
+* **[M6 P1] T-DDG-LAYOUT-1: Flex Alignment Coverage For Real Pages**; Goal: close major DDG homepage positioning gap; Scope: support `flex`, `flex-direction`, `flex-wrap`, `flex-basis`, `flex-shrink`, `align-items`, `justify-content`, `order` with enough fidelity for form/logo centering flows; Acceptance: DDG logo and search form center similarly to reference browser; Tests: layout regression fixture for DDG-like structure.
+* **[M6 P1] T-CSS-CLEAR-1: Float Clear Property**; Goal: prevent float/layout overlap in legacy page structures; Scope: parse/apply `clear` and integrate with block flow line placement; Acceptance: blocks that rely on `clear` no longer overlap preceding floated elements; Tests: block layout regressions.
+* **[M6 P2] T-LAYOUT-GRID-1: Grid Layout MVP**; Goal: minimal CSS Grid support; Scope: layout engine; Acceptance: fixed-track grids render; Tests: layout tests.
+
+### 6.2 - CSS Compatibility Slice
+
+* **[M6 P1] T-CSS-BORDER-COMPAT-1: Border Longhands And Corner Radius Longhands**; Goal: remove visible control chrome mismatches on real forms; Scope: add `border-top/right/bottom/left-color`, `border-top-left/right/bottom-left/bottom-right-radius`, and vendor aliases (`-moz-`, `-webkit-`) mapped to standard properties; Acceptance: DDG search control corners/borders match expected shape without split seams; Tests: parser/style/paint regressions.
+* **[M6 P2] T-CSS-COMPAT-ALIAS-1: Vendor Prefix Alias Layer**; Goal: reduce noisy unsupported-property fallout for legacy CSS; Scope: alias common prefixed properties to supported canonical forms where behavior is equivalent (`-webkit-user-select`, `-moz-appearance`, `-webkit-tap-highlight-color`, etc.) and silently ignore purely cosmetic no-op aliases; Acceptance: warning noise drops on DDG-like pages without behavioral regressions; Tests: parser alias tests.
+* **[M6 P2] T-CSS-MISC-LEGACY-1: Legacy Property Compatibility Slice**; Goal: close remaining DDG visual deltas not covered by flex/border work; Scope: targeted support for `text-shadow`, `visibility`, `pointer-events`, and legacy `clip` usage required by DDG assets/icons; Acceptance: DDG search icon/control visuals and hit behavior align with reference browser; Tests: style/layout interaction regressions.
+* **[M6 P2] T-ANIM-1: transition + transform (static)**; Goal: parse/apply transforms without timing engine; Scope: style + paint; Acceptance: transform affects paint matrix; Tests: renderer tests.
+
+### 6.3 - DDG Parity + Regression Harness
+
+* **[M6 P1] T-DDG-CSS-CORE-2: DDG CSS Compatibility Carryover**; Goal: finish the remaining DDG visual-compatibility deltas deferred from Milestone 5; Scope: extend CSS/layout compatibility to close search/logo alignment and control-chrome gaps on DDG HTML; Acceptance: DDG homepage matches reference layout for centered logo/search block and no severe control overlap; Tests: DDG manual checklist (`doc/checklists/m5_ddg_css_core.md`) plus targeted regressions.
+* **[M6 P1] T-DDG-E2E-1: Real DDG HTML Snapshot Regression Harness**; Goal: validate DDG usability end-to-end against a realistic fixture; Scope: add pinned DDG HTML snapshot fixture, drive focus/type/submit/navigation flow in headless tab/app harness, and assert no overlap/regression around search controls; Acceptance: CI fails if DDG-like typing/submit flow regresses; Tests: engine/app integration tests.
+
+### 6.4 - Architecture Guardrails
+
+* **[M6 P1] T-ARCH-GUARD-1: Dependency Guardrails in CI**; Goal: prevent cycle regressions after refactors; Scope: add automated check for package-level cycles (using clang-uml artifacts or include-graph checks) and fail CI on new violations; Acceptance: CI reports cycle regressions deterministically; Tests: tooling/CI smoke.
+* **[M6 P1] T-ARCH-GUARD-2: Clang-UML Diagram Signal Cleanup**; Goal: keep architecture diagrams actionable; Scope: tune config/filters to reduce template/anonymous noise and emit stable focused diagrams for package and engine pipeline views; Acceptance: diagrams highlight project classes/modules with low noise and are documented in dev guide; Tests: docs/tooling.
+
+### 6.5 - Performance & Memory Hygiene (bounded)
+
+* **[M6 P1] T-PERF-5: Batch Resource Updates**; Goal: coalesce resource arrivals into fewer style/layout passes; Scope: ResourceLoader + DocumentPipeline; Acceptance: heavy pages avoid repeated full rebuilds; Tests: engine perf tests.
+* **[M6 P1] T-PERF-4: Offscreen Raster Cache + Layer Invalidation**; Goal: repaint only dirty regions; Scope: renderer + engine invalidation; Acceptance: cached layers reused across frames; Tests: renderer perf tests.
+* **[M6 P1] T-CACHE-1: Tab Resource Eviction + Rehydrate**; Goal: evict resources/render tree for background tabs and restore on focus; Scope: Tab + ResourceStore; Acceptance: inactive tabs drop memory and reload on activation; Tests: engine tests.
+* **[M6 P1] T-DOM-1: Infinite Scroll DOM Virtualization**; Goal: cap live DOM/resources for unbounded feeds; Scope: DOM/layout + resource eviction; Acceptance: long feeds do not grow memory unbounded and can rehydrate when revisiting content; Tests: engine perf tests.
+* **[M6 P1] T-DOM-2: DOM Budget Failure UX**; Goal: show a stable error page and recovery action when DOM budget is exceeded; Scope: DocumentPipeline + ResourceLoader; Acceptance: budget failure shows user-facing page instead of blank reset; Tests: engine tests.
+
+### 6.6 - Polish
+
+* **[M6 P1] T-HIST-1: Visited Link State**; Goal: track visited URLs and apply `vlink` colors appropriately; Scope: history store + style resolution; Acceptance: visited anchors render with `vlink`/`:visited` color; Tests: engine/style tests.
+
+---
+
+## Execution Order Checklist
+
+P0: Layout Compatibility (North Star)
+- [ ] T-LAYOUT-FLEX-1: Flexbox Layout MVP
+- [ ] T-DDG-LAYOUT-1: Flex Alignment Coverage For Real Pages
+- [ ] T-CSS-CLEAR-1: Float Clear Property
+- [ ] T-CSS-BORDER-COMPAT-1: Border Longhands And Corner Radius Longhands
+- [ ] T-DDG-CSS-CORE-2: DDG CSS Compatibility Carryover
+
+P0: Guardrails (North Star)
+- [ ] T-DDG-E2E-1: Real DDG HTML Snapshot Regression Harness
+- [ ] T-ARCH-GUARD-1: Dependency Guardrails in CI
+
+P1: Compatibility + Hygiene (pull in as needed)
+- [ ] T-CSS-COMPAT-ALIAS-1: Vendor Prefix Alias Layer
+- [ ] T-CSS-MISC-LEGACY-1: Legacy Property Compatibility Slice
+- [ ] T-PERF-5: Batch Resource Updates
+- [ ] T-PERF-4: Offscreen Raster Cache + Layer Invalidation
+- [ ] T-CACHE-1: Tab Resource Eviction + Rehydrate
+- [ ] T-DOM-1: Infinite Scroll DOM Virtualization
+- [ ] T-DOM-2: DOM Budget Failure UX
+- [ ] T-HIST-1: Visited Link State
+- [ ] T-ARCH-GUARD-2: Clang-UML Diagram Signal Cleanup
+
+P2: Only if Schedule Allows
+- [ ] T-LAYOUT-GRID-1: Grid Layout MVP
+- [ ] T-ANIM-1: transition + transform (static)

--- a/doc/milestones/milestone7.md
+++ b/doc/milestones/milestone7.md
@@ -1,0 +1,239 @@
+> **Status: Planned** — pre-written 2026-07, two milestones ahead. Sanity-check scope
+> against the M6 outcome before kickoff; story structure is expected to hold.
+
+## Milestone 7 North Star Deliverable
+
+**Before (after Milestone 6):**
+
+* JS can eval, `getElementById`, set `textContent`, and receive `click`/`load` dispatch
+  on directly-targeted nodes — but there is no generic event system (no capture/bubble,
+  no `removeEventListener`, no event objects worth the name).
+* JS cannot *build* UI: no `createElement`/`appendChild`/`removeChild`, no
+  `querySelector`, no `innerHTML`.
+* Time does not exist: no `setTimeout`, no microtask pump (Promises resolve but their
+  jobs never run), no `requestAnimationFrame`.
+* Mutations from JS trigger coarse rebuilds rather than scoped invalidation.
+
+**After (Milestone 7 done):**
+
+* **A real, mutable, scriptable document**: JS builds and restructures the DOM through
+  standard primitives with strict arena ownership.
+* **Event System v1**: `addEventListener`/`removeEventListener`, real event objects,
+  capture → target → bubble propagation, keyboard/input/submit events routed from
+  Platform.
+* **Scheduling**: task queue (`setTimeout`/`setInterval`), microtask queue integrated
+  with the main-loop tick, `requestAnimationFrame`.
+* **Deterministic invalidation**: N mutations inside one handler produce one
+  style/layout/paint pass.
+* **Proof target:** a pinned **vanilla-JS TodoMVC snapshot** is fully usable — add,
+  toggle, edit, filter, clear-completed — in a CI harness.
+
+---
+
+## Non-Goals (keep the blast radius controlled)
+
+* No fetch/XHR or any networking JS API (M9). No cookies/storage bindings (M8).
+* No History API, no observer APIs (`MutationObserver` etc.), no custom elements (M12).
+* No Shadow DOM.
+* No exhaustive event-type coverage — an enumerated set (see 7.2.4) is the contract.
+* `innerHTML` reuses the existing recovery-oriented parser on a fragment; no separate
+  spec-grade fragment parsing algorithm.
+* No GC integration work beyond the documented ownership rules (no cycle collector
+  heroics; leaks across the JS/native boundary are acceptable if bounded and known).
+* No new threading (DOM/layout/style stays main-thread deterministic).
+
+---
+
+## Critical Path (what must land for the North Star)
+
+**Must-have**
+
+* DOM construction/mutation primitives with arena ownership (7.1.1) + `innerHTML` (7.1.4).
+* `querySelector`/`querySelectorAll` over the existing SelectorMatcher (7.1.3).
+* EventTarget with propagation and real event objects (7.2.1–7.2.3).
+* Keyboard/input/submit event routing (7.2.4) — TodoMVC is keyboard-driven.
+* Task + microtask queues in the main loop (7.3.1–7.3.2).
+* Batched invalidation per task (7.4.1).
+* TodoMVC snapshot harness in CI (7.5.1).
+
+**Nice-to-have (if schedule allows)**
+
+* `requestAnimationFrame` (7.3.3) — cheap once the frame tick owns the queues.
+* `classList`/`dataset` conveniences beyond what TodoMVC touches (7.1.2 minimum scope
+  is what the target needs).
+
+---
+
+## Milestone 7 Done When
+
+* TodoMVC (pinned snapshot) passes a scripted add/toggle/edit/filter/clear flow in the
+  headless harness, and CI fails on regression.
+* Capture/target/bubble order is correct for nested listeners (event-order tests).
+* A handler performing many mutations triggers exactly one style/layout/paint pass.
+* `setTimeout(fn, 0)` and Promise jobs interleave in spec order (task vs microtask
+  tests).
+* Missing-API telemetry and parser fuzzing run in CI (standing guardrails start here).
+* JS/native ownership rules are documented (`doc/dev_guide/`), and teardown tests show
+  no stale listeners or dangling node references after navigation.
+
+---
+
+## Stories
+
+### 7.1 - DOM Core (JS can build UI)
+
+* **Story 7.1.1: Mutation Primitives With Arena Ownership**
+* **Goal:** `createElement`, `createTextNode`, `appendChild`, `insertBefore`,
+  `removeChild`, `replaceChild`.
+* **Scope:** core/dom node factories + tree surgery; document the rule for nodes
+  created after initial parse (same arena; removal detaches, never frees).
+* **Acceptance:** JS builds a list of elements from scratch; removing/reinserting nodes
+  never corrupts the tree or the arena.
+* **Tests:** DOM mutation unit tests + invalidation integration tests.
+
+* **Story 7.1.2: Attributes, classList, dataset**
+* **Goal:** `getAttribute`/`setAttribute`/`removeAttribute`, `classList`
+  add/remove/toggle/contains, `dataset` read/write.
+* **Scope:** core/dom + JS bindings; class changes feed selector re-match.
+* **Acceptance:** toggling a class visibly restyles; `dataset.id` round-trips.
+* **Tests:** DOM + style invalidation tests.
+
+* **Story 7.1.3: querySelector / querySelectorAll**
+* **Goal:** subtree selector queries reusing SelectorMatcher.
+* **Scope:** traversal + matcher entry point + JS bindings (static NodeList snapshot).
+* **Acceptance:** the selector subset supported by the style engine works identically
+  from JS.
+* **Tests:** query tests mirroring existing selector-matcher coverage.
+
+* **Story 7.1.4: innerHTML (fragment parse)**
+* **Goal:** `element.innerHTML = "<li>…</li>"` replaces children via the existing
+  HTML parser in fragment mode.
+* **Scope:** parser fragment entry point + subtree teardown/attach; recovery behavior
+  matches document parsing.
+* **Acceptance:** TodoMVC's template-string rendering path works.
+* **Tests:** fragment parse + mutation tests, including malformed input.
+
+### 7.2 - Event System v1
+
+* **Story 7.2.1: EventTarget + Listener Registry**
+* **Goal:** `addEventListener`/`removeEventListener` with capture flag; listener
+  lifetimes tied to document teardown.
+* **Scope:** per-node listener storage (heap-side, keyed to arena nodes); teardown
+  sweep on navigation.
+* **Acceptance:** add/remove pairs behave; no stale callbacks after navigation.
+* **Tests:** listener lifecycle tests.
+
+* **Story 7.2.2: Event Objects**
+* **Goal:** `type`, `target`, `currentTarget`, `preventDefault`, `stopPropagation`,
+  key/char fields for keyboard events.
+* **Scope:** event struct + JS wrapper (per-dispatch, not retained).
+* **Acceptance:** `preventDefault` on submit stops navigation; `stopPropagation`
+  halts bubbling.
+* **Tests:** event semantics tests.
+
+* **Story 7.2.3: Capture/Target/Bubble Propagation**
+* **Goal:** full three-phase dispatch along the ancestor chain.
+* **Scope:** dispatch walk + phase bookkeeping.
+* **Acceptance:** listener order matches spec for nested capture/bubble combinations.
+* **Tests:** event-order integration tests.
+
+* **Story 7.2.4: Input Event Coverage (enumerated)**
+* **Goal:** route `keydown`, `keyup`, `input`, `change`, `submit`, `dblclick`,
+  `focus`, `blur` from Platform through the dispatch pipeline.
+* **Scope:** app/engine event routing → DOM dispatch; keep the Platform → Core
+  interface boundary intact.
+* **Acceptance:** TodoMVC's Enter-to-add, dblclick-to-edit, blur-to-commit flows work.
+* **Tests:** input-controller + dispatch integration tests.
+
+### 7.3 - Scheduling
+
+* **Story 7.3.1: Task Queue (setTimeout/setInterval)**
+* **Goal:** timer registration, ordering, `clearTimeout`/`clearInterval`; fired on the
+  main-loop tick.
+* **Scope:** engine-owned task queue; per-document isolation (timers die with the
+  document).
+* **Acceptance:** timers fire in order; navigation cancels a document's timers.
+* **Tests:** scheduling unit + teardown tests.
+
+* **Story 7.3.2: Microtask Pump (Promise jobs)**
+* **Goal:** drain the QuickJS job queue after every script entry point (event
+  dispatch, timer callback, eval), before yielding to layout/paint.
+* **Scope:** script engine adapter + main-loop integration. *(Hard prerequisite for
+  M9's `fetch`.)*
+* **Acceptance:** `Promise.resolve().then(...)` runs before the next task; task vs
+  microtask interleaving matches spec.
+* **Tests:** interleaving-order tests.
+
+* **Story 7.3.3: requestAnimationFrame**
+* **Goal:** rAF callbacks run once per frame before paint.
+* **Scope:** frame-tick hook; cancellation.
+* **Acceptance:** rAF-driven class toggling animates without queue growth.
+* **Tests:** frame-scheduling tests.
+
+### 7.4 - Invalidation Model
+
+* **Story 7.4.1: Batched Dirty Marking Per Task**
+* **Goal:** mutations mark style/layout/paint dirty; the pipeline runs once per task,
+  not per mutation.
+* **Scope:** DocumentPipeline dirty flags + flush point at end-of-task.
+* **Acceptance:** a handler doing 100 mutations produces exactly one pass (assert via
+  instrumentation, in the spirit of M5's injection budget).
+* **Tests:** invalidation budget tests.
+
+### 7.5 - Guardrails (standing, start here)
+
+* **Story 7.5.1: TodoMVC Snapshot Harness (T-TODOMVC-E2E-1)**
+* **Goal:** pinned vanilla-JS TodoMVC fixture driven headlessly through the full flow.
+* **Scope:** fixture + engine/app harness (pattern of M6's T-DDG-E2E-1).
+* **Acceptance:** CI fails when the flow regresses.
+* **Tests:** integration harness.
+
+* **Story 7.5.2: Missing-API Telemetry (T-JS-REG-1)**
+* **Goal:** once-per-page logging of unimplemented JS APIs/DOM properties touched by a
+  page (the JS-era T-SUPPORT-REG-1).
+* **Scope:** binding-layer trap/registry + report output.
+* **Acceptance:** loading a proof target emits a deduped missing-API list; this list
+  feeds the M12 backlog.
+* **Tests:** registry unit tests.
+
+* **Story 7.5.3: Parser Fuzzing In CI (T-FUZZ-1)**
+* **Goal:** libFuzzer harnesses for HtmlParser and CssParser with a seed corpus from
+  existing fixtures; short deterministic run in CI, longer runs local.
+* **Scope:** tooling + CI job; fix-forward policy for findings.
+* **Acceptance:** fuzz targets build and run in CI; crashes become regression inputs.
+* **Tests:** tooling smoke + accumulated corpus.
+
+* **Story 7.5.4: JS/Native Ownership Rules Documented**
+* **Goal:** write down who owns what across the boundary (arena nodes vs JS wrappers
+  vs listener registry) before M8/M9 build on it.
+* **Scope:** `doc/dev_guide/` entry + assertions where cheap.
+* **Acceptance:** rules doc exists; teardown tests reference it.
+* **Tests:** teardown/leak tests.
+
+---
+
+## Execution Order Checklist
+
+P0: DOM + Events (North Star)
+- [ ] 7.1.1: Mutation Primitives With Arena Ownership
+- [ ] 7.1.2: Attributes, classList, dataset
+- [ ] 7.1.3: querySelector / querySelectorAll
+- [ ] 7.1.4: innerHTML (fragment parse)
+- [ ] 7.2.1: EventTarget + Listener Registry
+- [ ] 7.2.2: Event Objects
+- [ ] 7.2.3: Capture/Target/Bubble Propagation
+- [ ] 7.2.4: Input Event Coverage
+
+P0: Scheduling + Invalidation (North Star)
+- [ ] 7.3.1: Task Queue (setTimeout/setInterval)
+- [ ] 7.3.2: Microtask Pump (Promise jobs)
+- [ ] 7.4.1: Batched Dirty Marking Per Task
+
+P0: Guardrails
+- [ ] 7.5.4: JS/Native Ownership Rules Documented
+- [ ] 7.5.1: TodoMVC Snapshot Harness
+- [ ] 7.5.2: Missing-API Telemetry
+- [ ] 7.5.3: Parser Fuzzing In CI
+
+P1: If Schedule Allows
+- [ ] 7.3.3: requestAnimationFrame

--- a/doc/milestones/milestone8.md
+++ b/doc/milestones/milestone8.md
@@ -1,0 +1,196 @@
+> **Status: Planned** — pre-written 2026-07, three milestones ahead but spec-driven
+> (cookies/storage are RFC-shaped and nearly independent of M6/M7 discoveries).
+> Sanity-check the network-seam story scopes against the codebase before kickoff.
+
+## Milestone 8 North Star Deliverable
+
+**Before (after Milestone 7):**
+
+* JS-driven pages work, but the browser is amnesiac: no cookie storage, so every
+  navigation is a first visit and no login survives a single page load.
+* No `localStorage`/`sessionStorage` — the state layer virtually every logged-in site
+  assumes is absent.
+* Redirect handling exists but has no cookie semantics and no hardening (limits, loop
+  detection, method rewriting).
+
+**After (Milestone 8 done):**
+
+* **Cookie engine v1**: Set-Cookie parsing, domain/path matching, Secure/HttpOnly,
+  SameSite baseline, correct behavior across redirects, persisted to disk.
+* **DOM Storage**: `localStorage` (persistent, per-origin) and `sessionStorage`
+  (per-tab lifetime).
+* **`document.cookie`** JS binding with HttpOnly filtering.
+* **Hardened navigation plumbing**: redirect limits/loop detection, 301/302/303/307/308
+  method semantics, basic network-error pages.
+* **Proof target:** **log into Hacker News, post a comment, restart the browser, and
+  still be logged in.**
+
+---
+
+## Non-Goals (keep the blast radius controlled)
+
+* No fetch/XHR (M9) — cookies/storage land first precisely so M9 requests inherit
+  correct semantics.
+* No IndexedDB, no Cache API, no storage events across tabs.
+* No cookie manager UI, no third-party-cookie blocking policy, no partitioning.
+* No encryption-at-rest for the cookie jar/storage files (plain per-profile files;
+  note the limitation).
+* No `__Secure-`/`__Host-` prefix enforcement beyond parsing (record as follow-up if
+  a target site forces it).
+
+---
+
+## Critical Path (what must land for the North Star)
+
+**Must-have**
+
+* Cookie jar with matching/attribute policy (8.1.1, 8.1.2) wired into every engine
+  request (document, subresource, POST).
+* Redirect cookie semantics + chain hardening (8.1.3, 8.3.1).
+* Jar persistence across restarts (8.1.4).
+* `document.cookie` binding (8.1.5) — HN's login flow is form-POST, but session
+  checks touch it.
+* `localStorage` with persistence (8.2.1, 8.2.2).
+* HN login/comment harness against a local fixture server (8.4.1).
+
+**Nice-to-have (if schedule allows)**
+
+* `sessionStorage` per-tab semantics (8.2.3) — cheap once 8.2.1 exists.
+* Network-error pages (8.3.2).
+
+---
+
+## Milestone 8 Done When
+
+* The HN flow passes manually against the live site: log in → post comment → restart
+  browser → still logged in.
+* The same flow passes in CI against a pinned-fixture local server (login form,
+  Set-Cookie, authenticated POST, session check).
+* Cookie matching/attribute tests pass (domain/path, expiry, Secure, HttpOnly,
+  SameSite Lax/Strict, redirect behavior).
+* `localStorage` data survives restart; `sessionStorage` dies with the tab; quotas
+  enforced.
+* No cookie or storage state leaks across tabs beyond spec (shared jar per profile,
+  per-origin storage; per-tab sessionStorage).
+
+---
+
+## Stories
+
+### 8.1 - Cookie Engine v1
+
+* **Story 8.1.1: Cookie Jar + Matching**
+* **Goal:** parse `Set-Cookie`, store cookies, and attach them to requests via
+  domain/path matching with expiry/max-age handling.
+* **Scope:** engine-owned jar (single profile) behind the network seam; libcurl's own
+  cookie engine stays off — the jar is engine-owned so policy is testable.
+* **Acceptance:** a server-set cookie is returned on the next matching request and
+  not on non-matching domain/path.
+* **Tests:** jar unit tests (matching matrix, expiry).
+
+* **Story 8.1.2: Attribute Policy (Secure/HttpOnly/SameSite)**
+* **Goal:** honor `Secure` (HTTPS-only), `HttpOnly` (hidden from JS), and SameSite
+  Lax-by-default with Strict supported.
+* **Scope:** jar policy + request-context plumbing (top-level vs subresource,
+  same-site computation).
+* **Acceptance:** attribute matrix behaves per baseline spec; Lax cookies attach on
+  top-level navigation but not cross-site subresources.
+* **Tests:** policy unit tests.
+
+* **Story 8.1.3: Redirect Cookie Semantics**
+* **Goal:** cookies set mid-chain apply to subsequent hops; site context is
+  recomputed per hop.
+* **Scope:** ResourceLoader redirect path + jar integration.
+* **Acceptance:** a login POST that 302s with `Set-Cookie` lands authenticated.
+* **Tests:** redirect-chain integration tests (fixture server).
+
+* **Story 8.1.4: Cookie Jar Persistence**
+* **Goal:** persist non-session cookies to a per-profile file; load at startup;
+  session cookies die with the process.
+* **Scope:** serialization + startup/shutdown hooks; corrupt-file recovery (start
+  empty, log).
+* **Acceptance:** restart preserves persistent cookies exactly; expired ones are
+  purged on load.
+* **Tests:** persistence round-trip tests.
+
+* **Story 8.1.5: document.cookie Binding**
+* **Goal:** JS read/write of non-HttpOnly cookies for the document's origin.
+* **Scope:** JS binding + jar filter path.
+* **Acceptance:** JS sees its own cookies but never HttpOnly ones; writes obey
+  attribute parsing.
+* **Tests:** binding tests.
+
+### 8.2 - DOM Storage
+
+* **Story 8.2.1: Storage Backing Store**
+* **Goal:** per-origin key/value store with quota (small, e.g. 5 MB/origin) and
+  deterministic eviction refusal (throw on quota, per spec).
+* **Scope:** engine-owned store, heap-side (not arena — outlives documents).
+* **Acceptance:** get/set/remove/clear/length/key behave; quota exceeded throws.
+* **Tests:** store unit tests.
+
+* **Story 8.2.2: localStorage Binding + Persistence**
+* **Goal:** `window.localStorage` bound to the per-origin store, persisted to disk
+  per profile.
+* **Scope:** JS binding + persistence (load lazily per origin; write-through or
+  flush-on-tick — pick and document).
+* **Acceptance:** values survive restart; origins are isolated.
+* **Tests:** binding + persistence tests.
+
+* **Story 8.2.3: sessionStorage (per-tab)**
+* **Goal:** same API, lifetime bound to the tab, not persisted.
+* **Scope:** per-tab store instance; navigation within the tab preserves it, closing
+  the tab drops it.
+* **Acceptance:** two tabs on the same origin see different sessionStorage.
+* **Tests:** tab-lifecycle storage tests.
+
+### 8.3 - Navigation Plumbing
+
+* **Story 8.3.1: Redirect Chain Hardening**
+* **Goal:** hop limit, loop detection, and method semantics (303 → GET, 307/308
+  preserve method/body).
+* **Scope:** ResourceLoader redirect handling.
+* **Acceptance:** pathological chains terminate with a clear error; POST → 302 → GET
+  behaves like reference browsers.
+* **Tests:** redirect matrix tests (fixture server).
+
+* **Story 8.3.2: Network Error Pages**
+* **Goal:** DNS failure/refused/timeout/TLS error render a stable internal error page
+  with a retry affordance instead of a blank document.
+* **Scope:** DocumentPipeline error path + internal page template.
+* **Acceptance:** killing the fixture server mid-navigation shows the error page;
+  retry works.
+* **Tests:** engine error-path tests.
+
+### 8.4 - Guardrails
+
+* **Story 8.4.1: Login-Flow Harness (T-HN-E2E-1)**
+* **Goal:** CI-runnable end-to-end session test: local fixture server serving an
+  HN-shaped login form → Set-Cookie → authenticated POST → restart → session check.
+* **Scope:** fixture server + headless harness (pattern of T-DDG-E2E-1/T-TODOMVC-E2E-1);
+  live-HN run stays a manual gate.
+* **Acceptance:** CI fails if any link in the session chain regresses.
+* **Tests:** integration harness.
+
+---
+
+## Execution Order Checklist
+
+P0: Cookies (North Star)
+- [ ] 8.1.1: Cookie Jar + Matching
+- [ ] 8.1.2: Attribute Policy (Secure/HttpOnly/SameSite)
+- [ ] 8.1.3: Redirect Cookie Semantics
+- [ ] 8.3.1: Redirect Chain Hardening
+- [ ] 8.1.4: Cookie Jar Persistence
+- [ ] 8.1.5: document.cookie Binding
+
+P0: Storage (North Star)
+- [ ] 8.2.1: Storage Backing Store
+- [ ] 8.2.2: localStorage Binding + Persistence
+
+P0: Guardrails
+- [ ] 8.4.1: Login-Flow Harness
+
+P1: If Schedule Allows
+- [ ] 8.2.3: sessionStorage (per-tab)
+- [ ] 8.3.2: Network Error Pages

--- a/doc/milestones/milestone9.md
+++ b/doc/milestones/milestone9.md
@@ -1,0 +1,172 @@
+> **Status: DRAFT — do not execute as written.** Pre-written 2026-07, four milestones
+> ahead. The API surface (fetch/CORS/cache) is spec-shaped and will hold, but this doc
+> has two hard dependencies to revalidate at kickoff: (1) M7's microtask pump must
+> exist exactly as specced (fetch is Promise-based); (2) the `browser.*` request-hook
+> design in 9.4 assumes the M5-era extension host shape. Rewrite story Scope lines
+> against the then-current codebase before starting.
+
+## Milestone 9 North Star Deliverable
+
+**Before (after Milestone 8):**
+
+* Pages can hold a session (cookies/storage), but JS cannot make a network request —
+  every SPA that renders from an API is a blank shell.
+* All resource loading is engine-initiated (document/CSS/images); there is no
+  JS-visible request surface, no CORS model, and no HTTP caching.
+
+**After (Milestone 9 done):**
+
+* **fetch() v1** (Promise-based, headers, redirects, JSON round-trips) and a minimal
+  **XHR** compatibility wrapper.
+* **CORS v1**, strict-by-default, relaxations only behind feature flags.
+* **HTTP cache v1**: in-memory, Cache-Control/ETag revalidation.
+* **`browser.*` request-filtering hook** + built-in **ad-block-lite** extension — the
+  extension API's second real consumer, making every later target page lighter.
+* **Proof target:** **HNPWA (Hacker News PWA)** browses live API data — story lists,
+  threads, pagination — rendered entirely from fetch responses.
+
+---
+
+## Non-Goals (keep the blast radius controlled)
+
+* No streaming bodies (request or response) — buffered only; streaming is recorded as
+  a follow-up for the media era.
+* No Service Workers, no Cache API, no background sync.
+* No cross-origin isolation features (COOP/COEP), no preflight cache tuning beyond a
+  simple TTL.
+* Ad-block-lite uses a tiny curated filter list with substring/domain rules — no
+  EasyList syntax engine.
+* No fetch niceties beyond the target's needs: no AbortController (unless HNPWA
+  forces it — telemetry will say), no FormData bodies beyond urlencoded/JSON.
+
+---
+
+## Critical Path (what must land for the North Star)
+
+**Must-have**
+
+* fetch() with Request/Response/Headers minimum surface (9.1.1) riding the M8 cookie
+  jar and M7 microtask pump.
+* Same-origin + CORS request classification, preflight, strict enforcement (9.2.1).
+* In-memory HTTP cache with revalidation (9.3.1) — HNPWA hammers the same endpoints.
+* HNPWA harness against a mock API server (9.5.1).
+
+**Nice-to-have (if schedule allows)**
+
+* XHR wrapper (9.1.2) — only if the chosen HNPWA build (or telemetry on other
+  targets) actually uses it.
+* Request-filtering hook + ad-block-lite (9.4.1, 9.4.2).
+* Preflight result caching (9.2.2).
+
+---
+
+## Milestone 9 Done When
+
+* HNPWA (pinned build) renders lists/threads/pagination from live API calls, and the
+  same flow passes in CI against a mock API server.
+* CORS matrix tests pass: simple vs preflighted, allowed vs blocked, credentials
+  behavior with the M8 cookie jar.
+* Cache tests pass: fresh hit (no request), stale revalidation (304 path), no-store
+  honored.
+* With ad-block-lite enabled, filtered requests never hit the network and pages still
+  render (if 9.4 lands).
+* Missing-API telemetry from the HNPWA run is triaged into the M12 backlog.
+
+---
+
+## Stories
+
+### 9.1 - fetch/XHR v1
+
+* **Story 9.1.1: fetch() Core**
+* **Goal:** `fetch(url, {method, headers, body})` returning a Promise of a Response
+  with `status`, `headers`, `text()`, `json()`.
+* **Scope:** JS binding → engine request path (cookie jar, redirects from M8 apply);
+  buffered bodies; per-document cancellation on navigation.
+* **Acceptance:** GET and POST(JSON/urlencoded) round-trip; in-flight fetches are
+  cancelled on document teardown without callbacks firing into a dead page.
+* **Tests:** binding + engine integration tests (mock server).
+
+* **Story 9.1.2: XHR Compatibility Wrapper**
+* **Goal:** minimal XMLHttpRequest (open/send/onreadystatechange/responseText/status)
+  implemented over the fetch path.
+* **Scope:** JS-side wrapper; no separate native path.
+* **Acceptance:** an XHR-based page (or the HNPWA variant that uses it) works.
+* **Tests:** wrapper tests.
+
+### 9.2 - CORS v1 (strict)
+
+* **Story 9.2.1: Request Classification + Enforcement**
+* **Goal:** same-origin vs cross-origin classification; simple vs preflighted
+  requests; `Access-Control-Allow-*` response checks; credentials mode interacting
+  correctly with the cookie jar.
+* **Scope:** engine request pipeline; strict by default, per-flag relaxation only.
+* **Acceptance:** disallowed cross-origin fetch rejects without exposing the
+  response; allowed one resolves.
+* **Tests:** CORS matrix tests (mock server).
+
+* **Story 9.2.2: Preflight Cache (simple TTL)**
+* **Goal:** avoid re-preflighting every request to the same endpoint.
+* **Scope:** small keyed cache honoring `Access-Control-Max-Age`.
+* **Acceptance:** repeated preflighted requests preflight once within TTL.
+* **Tests:** cache behavior tests.
+
+### 9.3 - HTTP Cache v1 (memory first)
+
+* **Story 9.3.1: Cache Core + Revalidation**
+* **Goal:** in-memory cache keyed by URL+method with Cache-Control baseline
+  (max-age, no-store, no-cache) and ETag/If-None-Match → 304 revalidation.
+* **Scope:** sits at the engine network seam so document, subresource, and fetch
+  traffic all benefit; bounded size with LRU eviction.
+* **Acceptance:** reload of a cached page issues conditional requests and reuses
+  bodies on 304; no-store is never cached.
+* **Tests:** cache unit + integration tests.
+
+### 9.4 - Extension Follow-Through (ad-block-lite)
+
+* **Story 9.4.1: Request-Filtering Hook**
+* **Goal:** `browser.webRequest`-lite: extensions register a synchronous
+  block/allow decision on request metadata (URL, type, initiator) before dispatch.
+* **Scope:** extension host API + engine request pipeline hook; deterministic
+  ordering; disabled extensions never consulted (M5 lifecycle rules apply).
+* **Acceptance:** a background script can block requests by pattern; blocking is
+  observable in resource state (Failed/Blocked, not hung).
+* **Tests:** extension API integration tests.
+
+* **Story 9.4.2: Built-In Ad-Block-Lite Extension**
+* **Goal:** ship the second canonical extension: small curated filter list
+  (domains + substrings), toggleable like Dark Mode.
+* **Scope:** background script + list format + docs.
+* **Acceptance:** a fixture page with tracker-shaped requests loads with them
+  blocked and renders correctly.
+* **Tests:** integration test + manual check on real pages.
+
+### 9.5 - Guardrails
+
+* **Story 9.5.1: HNPWA Harness (T-HNPWA-E2E-1)**
+* **Goal:** pinned HNPWA build + mock API server driven headlessly: load shell,
+  fetch list, open thread, paginate.
+* **Scope:** fixture + harness (pattern of the M6–M8 harnesses); live-site run stays
+  a manual gate.
+* **Acceptance:** CI fails when the fetch/render loop regresses.
+* **Tests:** integration harness.
+
+---
+
+## Execution Order Checklist
+
+P0: fetch + CORS (North Star)
+- [ ] 9.1.1: fetch() Core
+- [ ] 9.2.1: Request Classification + Enforcement
+
+P0: Cache (North Star)
+- [ ] 9.3.1: Cache Core + Revalidation
+
+P0: Guardrails
+- [ ] 9.5.1: HNPWA Harness
+
+P1: Pull In As Needed
+- [ ] 9.1.2: XHR Compatibility Wrapper
+- [ ] 9.2.2: Preflight Cache
+- [ ] 9.4.1: Request-Filtering Hook
+- [ ] 9.4.2: Built-In Ad-Block-Lite Extension

--- a/doc/milestones/roadmap.md
+++ b/doc/milestones/roadmap.md
@@ -1,301 +1,335 @@
-#Hummingbird Engine - Project Roadmap
+# Hummingbird Engine - Project Roadmap
 
-This document outlines the high - level path from an empty repository to a modular,
-    extension - ready browser engine.The philosophy is "Agile Iteration" : strictly modular components,
-    minimal memory footprint,
-    and progressive complexity.Current codebase modules live in `src / app`, `src / core`, `src / html`, `src / style`, `src / layout`, `src /
-                                                                                                                                            renderer`,
-    and `src / platform`; keep Ports & Adapters intact (Core/HTML/Layout never depend on Platform).
+This document outlines the high-level path from an empty repository to a browser that can
+realistically be used — which we define concretely: **it can play a YouTube video and
+scroll a TikTok feed**. If it can't do that, it's a weekend project, not a browser.
+
+The philosophy is "Agile Iteration": strictly modular components, minimal memory
+footprint, and progressive complexity. Current codebase modules live in `src/app`,
+`src/core`, `src/engine`, `src/html`, `src/style`, `src/layout`, `src/renderer`, and
+`src/platform`; keep Ports & Adapters intact (Core/HTML/Style/Layout never depend on
+Platform).
+
+**How this document relates to the others:**
+
+* This roadmap is the high-level index. Each active/completed milestone has a detailed
+  document (`doc/milestones/milestoneN.md`) with North Star deliverable, non-goals,
+  critical path, and stories.
+* `doc/TODOs.md` tracks the live backlog; completed items are archived in
+  `doc/todo_archive/`.
+* Status legend: **Done** (shipped, tag noted) / **Next** (detailed doc exists, work
+  queued) / **Planned** (themed, target chosen, not yet broken into stories) /
+  **Aspirational** (direction is committed, expect re-scoping before work starts).
+
+> **Renumbering note (2026-07):** Milestones 6+ were restructured twice-over. First,
+> "The Layouter" was pulled forward to M6 and "The Speedster" was merged into the
+> Compositor. Second, the back half (M7+) was rebuilt as a **compatibility ladder**
+> ending at YouTube/TikTok playback: the old Gmail/Instagram "viable demo" targets were
+> dropped from the mainline (they can return via the target matrix after the endgame),
+> and the old DOMster/Scripter++ pair was merged into one milestone since they shared a
+> single demo. Old numbers appear in archived docs.
 
 ---
 
-## Milestone 0: The Skeleton (Foundation)
-**Theme:** *Architecture & Abstraction* **Goal:** Establish the build system, core utilities, and platform abstractions without implementing browser logic yet.
+## The Compatibility Ladder (M6 → M16)
 
-* **Build System:** CMake/Meson setup separating `Core`, `Platform`, and `App`.
-* **Memory Model:** Implement `ArenaAllocator` for bulk DOM management.
-* **Platform Abstraction:**
-    * `IWindow`: Abstract interface for OS windows.
-    * `IGraphicsContext`: Abstract interface for 2D drawing.
-    * **Implementation:** SDL2 (Window) + Blend2D (Graphics).
+Every milestone from M6 onward is anchored to one real page that cannot work without
+that milestone's functional expansion. A milestone is done when its proof target works,
+not when its subsystem "looks finished."
+
+| Milestone | Proof target | Capability it forces |
+|---|---|---|
+| M6 Layouter | DDG HTML homepage (visual parity) | flexbox + CSS compat + CI harness |
+| M7 Programmable Document | TodoMVC (pinned snapshot) | DOM mutation + events + timers/microtasks |
+| M8 Session Keeper | Hacker News: log in, post a comment | cookies + storage + session persistence |
+| M9 Fetcher | HNPWA browsing live API data | fetch/XHR + CORS + HTTP cache |
+| M10 Layouter II | Wikipedia desktop + old.reddit | fixed/sticky + scroll containers + z-index |
+| M11 Inputter | Real login + rich text forms | focus, selection, clipboard, forms v2 |
+| M12 Framework Gauntlet | m.youtube.com app shell (no video) | observers + History API + SPA navigation |
+| M13 Media Engine I | TikTok embed plays one video | `<video>` progressive playback + audio |
+| M14 Compositor | Feed scrolls at 60fps while video plays | layers + retained rendering |
+| M15 Media Engine II | YouTube embed plays | MSE + adaptive streaming |
+| M16 Endgame | YouTube watch page + TikTok feed | the long tail, per-host flags |
+
+**Standing guardrails (start early, run forever):**
+
+* **Missing-API telemetry (from M7):** once-per-page logging of every JS API / DOM
+  property a proof target touches that we don't implement (the JS-era version of M4's
+  unsupported-tag registry). This list *is* the backlog generator for M12 and M16.
+* **Parser fuzzing (from M7):** libFuzzer harnesses over HtmlParser/CssParser in CI.
+  Arena allocation + raw observer pointers + real-web input demands it long before any
+  sandbox work.
+* **WPT slices (from M6):** import small curated web-platform-tests subsets per area
+  (start with a few dozen flexbox tests) so compatibility is a number that trends, not
+  a feeling.
+* **Perf budgets (tracked from M7, enforced from M14):** navigation→first-paint and
+  keystroke→paint measured on the fixture set from M7 on; hard budgets become CI
+  assertions when compositor work starts.
+* **Extension API follow-through (M9):** the `browser.*` layer gets its second real
+  consumer — a request-filtering hook and a built-in ad-block-lite extension. This also
+  makes M13+ target pages materially lighter.
+
+---
+
+## Milestone 0: The Skeleton (Foundation) — Done (v0.1.0, Dec 2025)
+
+**Theme:** *Architecture & Abstraction*
+**Goal:** Establish the build system, core utilities, and platform abstractions without implementing browser logic yet.
+
+* **Build System:** CMake setup separating `Core`, `Platform`, and `App`.
+* **Memory Model:** `ArenaAllocator` for bulk DOM management.
+* **Platform Abstraction:** `IWindow`, `IGraphicsContext`; implemented via SDL2 (window) + Blend2D (graphics).
 * **Deliverable:** A "Hello Engine" executable that opens a window and clears the screen.
 
 ---
 
-## Milestone 1: The Reader (HTML MVP)
-**Theme:** *Data to Pixels (MVC Pattern)* **Goal:** Render static HTML with hardcoded "User Agent" defaults and a working render tree. Current status: Epics 1.1–1.3 shipped; Epic 1.4 (flow/layout refinement) is next.
+## Milestone 1: The Reader (HTML MVP) — Done (v0.1.0, Dec 2025)
 
-* **HTML Pipeline (done):**
-    * Zero-copy tokenizer (`std::string_view`).
-    * DOM builder with open-element stack, void handling, and unsupported-tag logging.
-* **Style Defaults (done):**
-    * Hardcoded mapping for headings, lists (ul/ol indent), links (blue/underline), code, pre, hr, blockquote, strong/em.
-* **Layout Engine (partial):**
-    * Block layout: vertical stacking with margin/padding support.
-    * Inline layout: single-line flow for inline elements and text; BR/HR control objects.
-    * Next: render-tree construction refinements, greedy line breaking, and viewport-aware block flow.
-* **Viewport (upcoming within 1.4/1.7):**
-    * Greedy text wrapping.
-    * Basic scrolling/camera offset.
+**Theme:** *Data to Pixels (MVC Pattern)*
+**Goal:** Render static HTML with hardcoded "User Agent" defaults and a working render tree.
+
+* **HTML Pipeline:** Zero-copy tokenizer (`std::string_view`); DOM builder with open-element stack, void handling, and unsupported-tag logging.
+* **Style Defaults:** Hardcoded mapping for headings, lists, links, code, pre, hr, blockquote, strong/em.
+* **Layout Engine:** Block layout (vertical stacking, margin/padding), inline flow with greedy line breaking, BR/HR control objects.
+* **Viewport:** Text wrapping and basic scrolling/camera offset.
 * **Deliverable:** Visualize `mfw.html` legibly with headings, lists, inline links/code, and rules.
 
 ---
 
-## Milestone 2: The Stylist (CSS & Rendering)
-**Theme:** *Separation of Concerns* **Goal:** Replace hardcoded C++ styles with an external stylesheet pipeline.
+## Milestone 2: The Stylist (CSS & Rendering) — Done (v0.2.1, Jan 2026)
 
-* **CSS Parser (partial):** Tokenize/parse basic selectors and declarations (already present, will expand coverage).
-* **Cascade:** Apply selector specificity and compute styles for every node.
-* **Box Model Refinement:** Proper margins/padding/borders;
-`display : none` / `inline - block`.*** Deliverable : **Pages render differently based on a `.css` file; real bullets for lists via pseudo-element logic.
+Detailed doc: [milestone2.md](milestone2.md)
 
----
+**Theme:** *Separation of Concerns*
+**Goal:** Replace hardcoded C++ styles with an external stylesheet pipeline.
 
-## Milestone 3: The Navigator (The Web)
-**Theme:** *Connectivity & Interaction* **Goal:** Connect the engine to the internet and handle page transitions.
-
-* **Networking Layer:**
-    * Implement `INetwork` using **libcurl** (Multi-interface).
-    * **Concurrency:** Introduce the **IO Thread** to keep networking off the main UI loop.
-* **Interactivity:**
-    * **Hit Testing:** Determine which `RenderObject` is under the mouse.
-    * **Link Logic:** Clicking `<a>` triggers a network fetch and DOM tear-down/re-build.
-* **UI:**
-    * A simple URL bar and "Go" button.
-* **Deliverable:** A functional browser that can navigate from Wikipedia Home to an Article.
+* **CSS Parser:** Tokenize/parse selectors and declarations into arena-backed stylesheets.
+* **Cascade:** Selector specificity and computed styles for every node.
+* **Box Model Refinement:** Margins/padding/borders; `display: none` / `inline-block`.
+* **Deliverable:** Pages render differently based on a `.css` file; real bullets for lists via pseudo-element logic.
 
 ---
 
-## Milestone 4: The Brain (Scripting)
-**Theme:** *Logic & State* **Goal:** Embed a JavaScript engine to allow dynamic page content.
+## Milestone 3: The Navigator (The Web) — Done (v0.3.0, Jan 2026)
 
-* **JS Engine:** Integrate **QuickJS** (small footprint, easier C API).
-* **Bindings:**
-    * Expose `document`, `window`, and `console` to JS.
-    * Allow JS to modify the DOM (triggering re-layout).
-* **Events:** Hook up `onclick`, `onload` events from C++ to JS.
-* **Deliverable:** A page with a button that changes text color when clicked.
+Detailed doc: [milestone3.md](milestone3.md)
 
----
+**Theme:** *Connectivity & Interaction*
+**Goal:** Connect the engine to the internet and handle page transitions.
 
-## Milestone 5: The Architect (Extensions & UI)
-**Theme:** *Extensibility* **Goal:** Create the "Browser OS" layer that manages tabs and plugins.
-
-* **Extension API:**
-    * Create the `browser.*` JS API namespace.
-    * Allow loading "Background Scripts" (extensions) alongside the web page.
-* **Tab Management:**
-    * Isolate pages into separate `Tab` objects (logical isolation).
-* **Deliverable:** A browser that supports a "Dark Mode" extension which injects CSS into every loaded page.
+* **Networking Layer:** `INetwork` via libcurl; IO thread with main-thread handoff (DOM/layout stay main-thread).
+* **Engine Facade:** `Tab` owns the document lifecycle; `ResourceStore` state machine for HTML/CSS/images.
+* **Interactivity:** Hit testing; clicking `<a>` triggers fetch and document swap.
+* **UI:** URL bar with editing basics.
+* **Deliverable:** A functional browser that can navigate from a homepage to an article.
 
 ---
 
-## Milestone 6: The Speedster (Optimization)
-**Theme:** *Performance & Parallelism* **Goal:** Move from "functional" to "fast."
+## Milestone 4: The Brain (Scripting + Forms) — Done (v0.4.0, Feb 2026)
 
-* **Parallelism:**
-    * Move Paint Command generation to a separate thread?
-    * **Raster Thread:** Execute GPU commands separately from DOM logic.
-* **Compositing:**
-    * Implement layers (scrolling doesn't repaint the whole page, just moves a texture).
-* **Deliverable:** Smooth 60fps scrolling on complex pages.
+Detailed doc: [milestone4.md](milestone4.md)
 
----
+**Theme:** *Logic & State*
+**Goal:** Embed a JavaScript engine and make real search flows work without JS.
 
-## Milestone 7: The DOMster (DOM + Events Core)
-
-**Theme:** *Stateful Documents*
-**Goal:** Turn the HTML tree into a real, mutable DOM with a coherent event system and deterministic invalidation (style/layout/paint).
-
-* **DOM Core:**
-
-  * Node/Element/Text model hardened (attributes, `classList`, basic traversal).
-  * DOM mutation primitives (append/remove/replace) with strict arena ownership.
-* **Event System v1:**
-
-  * Capture/target/bubble propagation.
-  * Pointer + keyboard events routed from Platform → Core via interfaces.
-* **Invalidation Model:**
-
-  * Mutation marks style/layout/paint dirty regions (no “rebuild everything” on every change).
-* **Deliverable:** A toy SPA (no network) that builds UI via JS + DOM, responds to clicks, and updates layout correctly.
+* **JS Engine:** QuickJS behind `IScriptEngine` (Core stays QuickJS-free); eval + error reporting, no exceptions across the boundary.
+* **Bindings MVP:** `document.getElementById`, `textContent`, `console.log`; `click`/`load` event dispatch into JS.
+* **Forms MVP:** `<form>/<input>/<button>` rendering, focus + text editing, GET submit → navigation.
+* **Compatibility push:** selector coverage, entities, robust parsing, font-family mapping, warning registry.
+* **Deliverable:** DDG HTML search executes end-to-end; internal JS demo page proves scripted DOM mutation with single-pass invalidation.
 
 ---
 
-## Milestone 8: The Scripter++ (JS Bindings + Timers + Microtasks)
+## Milestone 5: The Architect (Extensions & Tabs) — Done (0.5.0 scope complete; release tag pending)
 
-**Theme:** *Programmable Web*
-**Goal:** Make JS-driven pages realistic: timers, microtasks, and enough DOM bindings to run small frameworks-lite patterns.
+Detailed doc: [milestone5.md](milestone5.md) · Archive: [milestone5_done.md](../todo_archive/milestone5_done.md)
 
-* **JS Runtime Integration:**
+**Theme:** *Extensibility*
+**Goal:** Create the "Browser OS" layer that manages tabs and extensions.
 
-  * One runtime per document/tab; strict boundary (no exceptions across C++).
-  * GC interaction rules documented (who owns what; arena-backed native nodes).
-* **Web API Surface v1:**
-
-  * `window`, `document`, `console`, `Element` basics.
-  * `addEventListener/removeEventListener`, event objects.
-* **Scheduling:**
-
-  * `setTimeout/setInterval`, task queue.
-  * Microtask queue (Promise jobs) integrated with main loop tick.
-* **Deliverable:** “TodoMVC-class” app where UI is generated by JS, with stable performance and no DOM corruption.
+* **Tab Management:** `TabManager` with per-tab isolation (document/resources/scripts), minimal tab strip + shortcuts.
+* **Extension Host MVP:** manifest v0, loader, long-lived background script runtime (one QuickJS context per extension), enable/disable lifecycle.
+* **`browser.*` API v0:** tab lifecycle events, active-tab query, `insertCSS` with deterministic single-pass invalidation.
+* **Built-in Dark Mode extension** injecting CSS across pages and navigations.
+* **DDG completion track:** autofocus, input-submit parity, POST forms, hit-test reliability.
+* **Architecture paydown:** package cycles broken (document/script, platform_api/geometry, dom/compute), `DocumentPipeline`/`ResourceLoader` decomposition.
+* **Deliverable:** Multi-tab browser with a working Dark Mode extension; DDG HTML usable end-to-end.
 
 ---
 
-## Milestone 9: The Networker (Phased: Cookies → Fetch → Cache → History)
+## Milestone 6: The Layouter (Real-Page Layout Compatibility) — Next
 
-**Theme:** *App-Grade Connectivity*
-**Goal:** Support modern web app networking patterns in incremental, testable steps.
+Detailed doc: [milestone6.md](milestone6.md)
 
-This milestone is intentionally split into phases so it doesn’t become a “big bang” rewrite.
+**Theme:** *Modern Layout Primitives, Proven on a Real Page*
+**Goal:** Implement the layout features real pages assume by default (flexbox first), close the remaining DDG visual gaps, and lock progress in with automated regression harnesses.
 
-### Milestone 9A: Cookies v1 + Redirect/Response Plumbing
-
-* **Cookies (storage + policy)**
-  * Domain/path matching, Secure/HttpOnly.
-  * SameSite baseline (Lax/Strict minimum).
-* **Redirect behavior**
-  * Follow redirects with correct cookie semantics.
-* **Deliverable:** A site that relies on cookies across navigations works (even if no JS fetch yet).
-
-### Milestone 9B: Fetch/XHR v1 + CORS (Strict)
-
-* **Fetch/XHR v1**
-  * Request/response headers, redirects, buffering (streaming later).
-* **CORS v1**
-  * Start strict; expand behind feature flags.
-* **Deliverable:** A JS app can make API calls (GET/POST) and render based on responses.
-
-### Milestone 9C: HTTP Cache v1 (Memory First)
-
-* **Cache basics**
-  * ETag / If-None-Match, Cache-Control baseline, in-memory cache first.
-* **Deliverable:** Reloading an app reduces network traffic and time-to-interactive.
-
-### Milestone 9D: Navigation Model v2 (History + Lifecycle)
-
-* **History baseline**
-  * back/forward, reload, and stable lifecycle without leaks or dangling `std::string_view`.
-  * push/replace state can be partial initially.
-* **Deliverable:** A JS-heavy site survives refresh/back/forward without corrupting document state.
+* **Flexbox v1:** row/column, alignment, basic flex factors — enough fidelity for form/logo centering on real pages.
+* **CSS compatibility slice:** `clear`, border/radius longhands, vendor-prefix aliases, targeted legacy properties.
+* **DDG parity:** homepage matches reference browser for the centered logo/search block.
+* **Guardrails:** DDG snapshot regression harness in CI; automated dependency-cycle checks; first WPT flexbox slice.
+* **Perf/memory hygiene (bounded):** batch resource updates, tab resource eviction, DOM budgets — only as far as real pages force it.
+* **Proof target:** DDG HTML homepage renders like a reference browser, and CI fails if the type/submit/navigate flow or the layout regresses.
 
 ---
 
-## Milestone 10: The Layouter (Flexbox + Fixed/Sticky + Scroll Containers)
+## Milestone 7: The Programmable Document (DOM + Events + Scheduling) — Planned
 
-**Theme:** *Modern Layout Primitives*
-**Goal:** Implement the layout features that modern UIs assume by default.
+Detailed doc: [milestone7.md](milestone7.md)
 
-* **Flexbox v1:**
+**Theme:** *A Real, Mutable, Scriptable Page*
+**Goal:** Merge the old "DOMster" and "Scripter++" milestones (they shared one demo) into a single expansion: JS can build and mutate UI, and time exists.
 
-  * Row/column, main/cross alignment, basic flex factors.
-* **Positioning v1:**
-
-  * `position: fixed` (non-negotiable), `absolute` correctness improvements.
-  * `sticky` (phase 2 if needed, but planned in architecture now).
-* **Overflow + Scrolling v2:**
-
-  * Real scroll containers (not just document scroll), clip/scroll offsets.
-  * Hit-testing respects scroll transforms.
-* **Stacking Context v1:**
-
-  * z-index basics to keep headers/menus sane.
-* **Deliverable:** Gmail-like header/sidebar layout renders correctly and scrolls without repainting the world.
+* **DOM Core:** mutation primitives (append/remove/replace) with strict arena ownership; `classList`, attributes, `dataset`; `querySelector`/`querySelectorAll`.
+* **Event System v1:** `addEventListener`/`removeEventListener`, real event objects, capture/target/bubble propagation; pointer + keyboard routed Platform → Core via interfaces.
+* **Scheduling:** `setTimeout`/`setInterval` task queue; microtask queue (Promise jobs) integrated with the main-loop tick; `requestAnimationFrame`. *(Microtasks are a hard prerequisite for M9's `fetch` — Promises don't work without them.)*
+* **Invalidation Model:** mutations mark style/layout/paint dirty regions (no "rebuild everything").
+* **Guardrails start:** missing-API telemetry; parser fuzzing in CI; GC/ownership rules documented (who owns what; arena-backed native nodes).
+* **Proof target:** **TodoMVC (vanilla-JS build, pinned snapshot)** is fully usable — add, toggle, edit, filter, clear — with stable performance and no DOM corruption.
 
 ---
 
-## Milestone 11: The Inputter (Forms v2, Focus, Selection, Clipboard)
+## Milestone 8: The Session Keeper (Cookies + Storage + Identity) — Planned
+
+Detailed doc: [milestone8.md](milestone8.md)
+
+**Theme:** *The Browser Remembers You*
+**Goal:** Support the state layer every logged-in site assumes.
+
+* **Cookies v1:** domain/path matching, Secure/HttpOnly, SameSite baseline (Lax/Strict); correct semantics across redirects; persistent cookie jar across restarts.
+* **DOM Storage:** `localStorage`/`sessionStorage` (synchronous API, per-origin, persisted). Every SPA login flow touches this — it cannot wait for the fetch milestone.
+* **Navigation plumbing:** POST hardening, redirect chains, basic error pages.
+* **Proof target:** **Log into Hacker News, post a comment, restart the browser, still be logged in.**
+
+---
+
+## Milestone 9: The Fetcher (Fetch/XHR + CORS + Cache) — Planned
+
+Detailed doc: [milestone9.md](milestone9.md) *(draft — revalidate at kickoff)*
+
+**Theme:** *Pages That Talk to APIs*
+**Goal:** JS-driven networking, done strictly.
+
+* **Fetch/XHR v1:** request/response headers, redirects, buffering (streaming later); JSON round-trips.
+* **CORS v1:** strict first; expand behind feature flags.
+* **HTTP Cache v1:** ETag / If-None-Match, Cache-Control baseline, in-memory first.
+* **Extension follow-through:** request-filtering hook in `browser.*` + built-in **ad-block-lite** extension — the API's second real consumer, and it makes every later target page lighter.
+* **Proof target:** **HNPWA (Hacker News PWA)** browses live API data — lists, threads, pagination — rendered entirely from `fetch` responses.
+
+---
+
+## Milestone 10: The Layouter II (Fixed/Sticky + Scroll Containers + Stacking) — Planned
+
+**Theme:** *Layout Features Deferred From M6*
+**Goal:** The positioning/scrolling primitives that desktop-class pages assume.
+
+* **Positioning:** `position: fixed` (non-negotiable), `sticky`, `absolute` correctness improvements.
+* **Overflow + Scrolling v2:** real scroll containers (not just document scroll), clip/scroll offsets, hit-testing through scroll transforms.
+* **Stacking Context v1:** z-index basics so headers/menus layer sanely.
+* **History baseline:** back/forward/reload with a stable document lifecycle (no leaks, no dangling `string_view`) — needed before SPA navigation in M12.
+* **Proof target:** **Wikipedia desktop and old.reddit** render with sticky/fixed headers, scrollable panes, and correct layering, and back/forward works through a browse session.
+
+---
+
+## Milestone 11: The Inputter (Forms v2, Focus, Selection, Clipboard) — Planned
 
 **Theme:** *Human Interaction*
-**Goal:** Make login and composing text practical (this is where “viable” often lives or dies).
+**Goal:** Make login and composing text practical (this is where "viable" often lives or dies).
 
-* **Form Controls v2:**
-  * Milestone 4 covers “forms MVP” (basic input/button + GET submit). This milestone expands it into “usable for real logins”.
-  * `<input type=text/password>`, `<textarea>`, `<button>` behavior.
-  * Value editing, selection, caret movement, copy/paste.
-* **Focus System:**
-
-  * Tab order, focus rings (style optional), keyboard routing.
-* **Composition Plan:**
-
-  * Latin input “good enough” first.
-  * IME/composition events as a follow-up epic (kept behind interfaces).
-* **Deliverable:** Log into a major site reliably and type into rich-ish forms without constant glitches.
+* **Form Controls v2:** `<input type=text/password>`, `<textarea>`; value editing, selection, caret movement, copy/paste.
+* **Focus System:** tab order, focus rings, keyboard routing.
+* **Composition Plan:** Latin input "good enough" first; IME/composition events as a follow-up epic behind interfaces.
+* **Text rendering reality check:** emoji + font-fallback chain baseline (comment sections are full of them; full shaping/bidi stays deferred).
+* **Proof target:** **Log into a major site (e.g., GitHub or Wikipedia) reliably**; write, select, copy/paste, and edit multi-line text without glitches.
 
 ---
 
-## Milestone 12: The Media Engine (Images + Video Playback, MVP First)
+## Milestone 12: The Framework Gauntlet (Observers + History API + SPA Navigation) — Aspirational
 
-**Theme:** *Pixels That Move*
-**Goal:** Make media functional first, then rely on compositor work for “smooth”.
+**Theme:** *Survive a Production Framework*
+**Goal:** The API surface that framework-generated apps (Polymer/React/Vue class) assume, driven directly by missing-API telemetry from the proof target.
 
-* **Image Pipeline v2:**
-
-  * Decoding breadth (jpeg/png/gif/webp as planned), caching, and correct sizing.
-* **`<video>` v1:**
-
-  * Decode + present frames, audio output, basic controls.
-  * Fullscreen (platform adapter).
-* **Streaming Strategy:**
-
-  * Phase 1: progressive MP4/HLS-if-easy.
-  * Phase 2 (likely required for real YouTube): MSE/DASH support.
-* **Deliverable:** Videos play on a “watch page” (performance may be limited); “smooth feed scrolling” is a Milestone 13/14 goal.
+* **History API:** `pushState`/`replaceState`/`popstate`; SPA route changes without document teardown.
+* **Observer APIs:** `MutationObserver`; `IntersectionObserver` (feeds/lazy-loading depend on it); `ResizeObserver` (stub → real as telemetry demands).
+* **Custom Elements:** `customElements.define()` upgrade path with lifecycle callbacks (YouTube is Polymer — this is not optional for the endgame).
+* **Long-tail bindings:** whatever the telemetry log says the target shell touches (`getBoundingClientRect`, `matchMedia`, `navigator.*` basics, etc.).
+* **Proof target:** **m.youtube.com renders its app shell** — thumbnails, navigation between pages — with video playback explicitly out of scope.
 
 ---
 
-## Milestone 13: The Compositor (Retained Rendering + Layers)
+## Milestone 13: The Media Engine I (Progressive Video + Audio) — Aspirational
 
-**Theme:** *Don’t Repaint the World*
-**Goal:** Make scrolling and animations usable on JS-heavy pages.
+**Theme:** *Pixels That Move, Sound That Plays*
+**Goal:** Functional `<video>`/`<audio>` for progressive (non-adaptive) sources. TikTok serves progressive MP4, which is why it comes a full milestone before YouTube.
 
-* **Retained Display List:**
-
-  * Build once, diff on invalidation; stable IDs for render nodes.
-* **Layer Tree:**
-
-  * Scroll layers move as textures; minimal repaint.
-* **Raster Strategy:**
-
-  * Keep DOM/layout on main thread; optionally add a raster thread behind Platform later.
-* **Deliverable:** 60fps-class scrolling on heavy feeds and mail lists on mid-tier hardware (enables the “smooth media” targets in Milestone 14).
+* **Decode adapters:** `IVideoDecoder`/`IAudioOutput` behind Platform (ffmpeg/libav + SDL audio are the obvious backends); Core never sees codec types.
+* **`<video>` v1:** frame presentation into the render tree, play/pause/seek on progressive MP4, volume, basic controls, fullscreen (platform adapter).
+* **A/V sync:** audio-clock-driven; frame drops over stalls.
+* **Image Pipeline v2 leftovers:** animated formats, caching, correct sizing under flex.
+* **Proof target:** **A TikTok embed page plays a single video with sound**, plus a local fixture page for deterministic CI.
 
 ---
 
-## Milestone 14: The “Viable” Demo (Gmail + Instagram + YouTube Targets)
+## Milestone 14: The Compositor (Layers + Retained Rendering) — Aspirational
 
-**Theme:** *Proof Over Promises*
-**Goal:** Turn “it should work” into a measurable compatibility claim with explicit limitations.
+**Theme:** *Don't Repaint the World*
+**Goal:** Smooth scrolling and cheap video presentation. (Absorbs the old "Speedster" milestone.)
 
-* **Target Matrix + Feature Flags:**
-
-  * Per-host compatibility toggles (strictly isolated; no engine-wide hacks without a plan).
-* **Gmail Baseline:**
-
-  * Login, inbox list, open thread, basic compose/send (limitations acceptable).
-* **Instagram Baseline:**
-
-  * Login, feed scroll, open post, view images/reels (upload optional).
-* **YouTube Baseline:**
-
-  * Open watch page, play video with audio, scrub, fullscreen (comments optional).
-* **Deliverable:** A public “3-site demo build” with a short known-issues list and repeatable repro scripts.
+* **Retained Display List:** build once, diff on invalidation; stable IDs for render nodes.
+* **Layer Tree:** scroll layers move as textures; video gets its own layer so playback doesn't force page repaints.
+* **Raster Strategy:** DOM/layout stay main-thread; optional raster thread behind Platform.
+* **Perf budgets become CI assertions:** navigation→first-paint, keystroke→paint, scroll frame time on the fixture set.
+* **Proof target:** **A feed-scroll harness (TikTok-like snapshot) scrolls at 60fps-class smoothness while a video keeps playing.**
 
 ---
 
-## (Optional, after “viable”) Milestone 15: The Safety Engineer (Process Model + Sandbox Plan)
+## Milestone 15: The Media Engine II (MSE + Adaptive Streaming) — Aspirational
 
-**Theme:** *Don’t Get Users Owned*
-**Goal:** Begin a path toward real-world safety (even if still not “Firefox-grade”).
+**Theme:** *Streaming Like the Real Ones*
+**Goal:** Media Source Extensions — the way YouTube actually delivers video.
 
-* **Site Isolation Plan:**
+* **MSE v1:** `MediaSource`/`SourceBuffer`, append/remove, buffered ranges, the buffering state machine.
+* **Byte-range fetch integration** with the M9 network stack; adaptive quality switching (manual first, automatic later).
+* **Workers decision:** Web Worker v1 or a documented stub — whatever the YouTube player build requires (telemetry decides).
+* **Explicit non-goal:** no EME/DRM. Standard videos only; DRM content will not play, and that's an accepted limitation.
+* **Proof target:** **A YouTube embed page plays a video** with scrub and at least one resolution switch.
 
-  * At minimum: per-tab process separation design doc + prototype.
-* **Permissions Model:**
+---
 
-  * Camera/mic/geolocation off by default; explicit prompts later.
-* **Hardening:**
+## Milestone 16: The Endgame (YouTube Watch Page + TikTok Feed) — Aspirational
 
-  * Input sanitization audits, fuzzing hooks, CSP basics later.
-* **Deliverable:** “We have a credible plan and prototype direction” (not full security parity).
+**Theme:** *A Browser Somebody Could Actually Use*
+**Goal:** Close the long tail on the two endgame targets, driven by telemetry, guarded by per-host flags.
+
+* **Target Matrix + Feature Flags:** per-host compatibility toggles, strictly isolated; no engine-wide hacks. (Other sites — Gmail, Instagram, anything — can be added to the matrix *after* the endgame; they are explicitly not on the critical path.)
+* **YouTube baseline:** open a watch page on youtube.com/m.youtube.com → video plays with audio, scrub, fullscreen. Comments/login optional.
+* **TikTok baseline:** open tiktok.com → scroll the feed, videos autoplay with sound. Login/upload optional.
+* **iframe v1 (if forced):** same-process, no sandbox — only if the targets require it for embeds/players; otherwise it stays deferred.
+* **Known risk, stated honestly:** both sites run anti-bot detection (TLS/JS fingerprinting) that may block an unknown engine regardless of technical capability. Mitigations: develop against pinned snapshots + embed endpoints first, keep the live-site check a manual gate, and decide UA policy when we get there.
+* **Deliverable:** a public demo build + short known-issues list + repeatable repro scripts proving both baselines.
+
+---
+
+## (Optional, post-endgame) Milestone 17: The Safety Engineer (Process Model + Sandbox Plan) — Aspirational
+
+**Theme:** *Don't Get Users Owned*
+**Goal:** Begin a path toward real-world safety (parser fuzzing already runs from M7; this is the structural half).
+
+* **Site Isolation Plan:** per-tab process separation design doc + prototype.
+* **Permissions Model:** camera/mic/geolocation off by default.
+* **Hardening:** input sanitization audits, CSP basics.
+* **Deliverable:** "We have a credible plan and prototype direction" (not full security parity).
+
+---
+
+## Explicitly deferred subsystems (tracked so they don't vanish)
+
+These are known gaps with no milestone of their own; each is pulled in only when a proof
+target forces it, and the decision (build/stub/reject) gets recorded here:
+
+* **iframes** — M16 if forced by embeds/players.
+* **Service workers** — stub/ignore until a target breaks without them (YouTube/TikTok load without on first visit).
+* **Canvas/WebGL** — not needed for the endgame playback path; revisit post-M16.
+* **Full text shaping/bidi (HarfBuzz-class)** — emoji + fallback baseline lands in M11; real shaping is post-endgame.
+* **EME/DRM** — rejected for the roadmap horizon.
+* **Accessibility beyond landmark roles** — revisit post-endgame; keep roles working meanwhile.


### PR DESCRIPTION
## Summary

**Roadmap restructure** (docs only):
- Repairs `roadmap.md` (formatting corruption, stale M1-era status notes) and adds per-milestone status (`Done vX.Y.Z` / Next / Planned / Aspirational) with links to detailed milestone docs.
- Renumbers M6+ to match reality: **The Layouter is now M6 (Next)**, the old "Speedster" is merged into the Compositor. The back half is rebuilt as a **compatibility ladder** — every milestone is one functional expansion proven by one real page, ending at the stated endgoal: **YouTube watch page + TikTok feed playback** (M16).
- New milestone docs in the established template (North Star / non-goals / critical path / stories / checklist):
  - `milestone6.md` — The Layouter (flexbox + DDG parity + CI harnesses), from the existing M6 backlog
  - `milestone7.md` — The Programmable Document (DOM/events/timers/microtasks; TodoMVC proof target)
  - `milestone8.md` — The Session Keeper (cookies/storage; HN login proof target)
  - `milestone9.md` — The Fetcher (fetch/CORS/cache; **explicit draft**, revalidate at kickoff)
- Standing guardrails written into the plan: missing-API telemetry, parser fuzzing in CI, WPT slices, perf budgets, extension-API follow-through (ad-block-lite).
- Explicitly-deferred subsystem list (iframes, service workers, text shaping, EME/DRM) so gaps stay visible.
- `TODOs.md` reindexed to the milestone docs (conflict with the M4-blockers archive section from master resolved by keeping both).

**License change:**
- Relicenses the project from Apache-2.0 to **AGPL-3.0-or-later** with an additional permission under section 7 allowing app-store distribution.
- README and CONTRIBUTING updated; `NOTICE` retained for third-party attribution (Roboto stays Apache-2.0, correctly).

## Notes for review
- `milestone9.md` carries a loud DRAFT banner on purpose — docs further out than M8 were judged to drift into fiction.
- Roadmap still says M5 "release tag pending" — there is no `v0.5.0` tag yet; tagging stays a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
