### PR TITLE
docs: polish agent-facing and contributor docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,6 @@ cmake_install.cmake
 CMakeUserPresets.json
 CTestTestfile.cmake
 Testing/Temporary/*
+cmake_test_discovery_*.json
 .gemini/settings.json
-.gitignore
 debug.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,42 @@
 # Agent Notes
-- Every generated code should adhere to doc/coding_constitution.md
-- if you find a conflict between doc/milestones/roadmap.md and current story, point it out and sugest architectually cleanest solution.
-- if during the course of programming a new task appears that doesnt really fit current scope of work add it as a future story into doc/TODOs.md
-- Before every commit that changed code cmake should be used to build the project using preset in CMakeUserPresets.json
-- Before every commit that changed code ctest should be run
-- For include audits, use include-what-you-use (if available)(`iwyu_tool.py -p build`) and apply suggestions with `fix_includes.py`.
-- Ensure `CMAKE_EXPORT_COMPILE_COMMANDS=ON` so IWYU can read `build/compile_commands.json`.
-- Before commit clang-format -i -- src/**/*.cpp' 'src/**/*.h should be run to format the code
-- after every self contained code change is made, make a git commit in the best practices format (feat/chore/fix/breaking/doc: msg)
- 
+
+Hummingbird is a C++20 browser engine (HTML → DOM → style → layout → paint) built as
+strictly separated modules. Read the pointers below instead of re-deriving project
+rules; keep this file thin — detailed rules live in the linked docs.
+
+## Document map
+
+- `doc/coding_constitution.md` — architecture and coding rules. **All generated code
+  must adhere to it** (Ports & Adapters firewall, arena memory, no exceptions, naming).
+- `doc/milestones/roadmap.md` — milestone index and statuses. The active milestone's
+  `doc/milestones/milestoneN.md` defines the current scope and story format.
+- `doc/TODOs.md` — live backlog index.
+- `doc/dev_guide/` — step-by-step guides for recurring workflows (e.g. adding CSS
+  properties). Check for a matching guide before implementing; if you repeat a
+  workflow that has no guide, add one.
+- `doc/tech_debt_game_plan.md` — tracked refactoring seams. When touching a file
+  listed there, prefer the planned decomposition over ad-hoc changes.
+
+## Workflow rules
+
+- If the current story conflicts with `doc/milestones/roadmap.md`, point it out and
+  suggest the architecturally cleanest resolution before coding.
+- If a new task appears during work that does not fit the current scope, add it to
+  `doc/TODOs.md` as a future story (match the existing `T-*` story format).
+- Make a git commit after every self-contained change, in conventional format:
+  `feat|fix|chore|docs|refactor|test: message`.
+
+## Before every commit that changes code
+
+1. Build: `cmake --preset ninja-multi-vcpkg && cmake --build --preset ninja-multi-vcpkg --config Release`
+   (if `CMakeUserPresets.json` provides a local preset, use that one).
+2. Test: `ctest --preset ninja-multi-vcpkg -C Release --output-on-failure`
+3. Format: `clang-format -i` over the touched files under `src/` (CI enforces
+   formatting for `src/**`).
+
+## Include audits (when asked, or when includes look bloated)
+
+- Use include-what-you-use if available: `iwyu_tool.py -p build`, apply suggestions
+  with `fix_includes.py`.
+- Requires `CMAKE_EXPORT_COMPILE_COMMANDS=ON` so IWYU can read
+  `build/compile_commands.json`.

--- a/README.md
+++ b/README.md
@@ -254,6 +254,14 @@ HB_EXTENSIONS_DISABLE=dark-mode ./build/Release/Hummingbird
 HB_EXTENSIONS_ENABLE=dark-mode,my-ext ./build/Release/Hummingbird
 ```
 
+## Documentation
+
+- Roadmap and milestone status: [`doc/milestones/roadmap.md`](doc/milestones/roadmap.md)
+- Live backlog: [`doc/TODOs.md`](doc/TODOs.md)
+- Architecture and coding rules: [`doc/coding_constitution.md`](doc/coding_constitution.md)
+- Developer workflow guides: [`doc/dev_guide/`](doc/dev_guide/)
+- Agent/automation entry point: [`AGENTS.md`](AGENTS.md)
+
 ## License
 
 Hummingbird is licensed under the GNU Affero General Public License v3.0 or later

--- a/doc/coding_constitution.md
+++ b/doc/coding_constitution.md
@@ -1,12 +1,4 @@
-This is an excellent idea. Establishing a "constitution" for your codebase early is the only way to keep a project of this complexity from collapsing under its own weight.
-
-Below is a **Design & Architecture Guide** tailored specifically for **Hummingbird** (your engine). It combines general "Clean Code" principles with the specific C++20/Browser constraints we discussed.
-
-You can save this as `DESIGN_GUIDE.md` in the root of your repository.
-
----
-
-# Hummingbird Engine – Design & Contribution Guide
+# Hummingbird Engine – Coding Constitution
 
 This document outlines the architectural principles, coding standards, and best practices for the Hummingbird browser engine. All code submitted to the project must adhere to these guidelines to ensure modularity, performance, and maintainability.
 
@@ -14,7 +6,7 @@ This document outlines the architectural principles, coding standards, and best 
 
 ### 1.1. The "Ports & Adapters" Rule (Strict Modularity)
 
-* **Core Logic is Sacred:** The `src/core`, `src/html`, and `src/layout` modules **must never** depend on `src/platform`.
+* **Core Logic is Sacred:** Every module except `src/platform` and `src/app` (`src/core`, `src/html`, `src/style`, `src/layout`, `src/renderer`, `src/engine`) **must never** depend on `src/platform`. This is enforced by `tests/core/DependencyFirewall.test.cpp`.
 * **Inversion of Control:** If the Core needs to draw pixels or fetch data, it must define an **Interface** (e.g., `IGraphicsContext`, `INetwork`). The Platform layer implements these interfaces.
 * **Dependency Injection:** Do not instantiate concrete platform classes inside the core. Pass them in during initialization.
 
@@ -220,10 +212,16 @@ Browser engines are performance-critical. Avoid `try/catch` in hot paths (parsin
 
 All code must reside in the `Hummingbird` namespace, with sub-namespaces for modules:
 
-* `Hummingbird::Core`
-* `Hummingbird::Html`
-* `Hummingbird::Layout`
-* `Hummingbird::Platform`
+* `Hummingbird::Core` (utilities, arena, platform API interfaces)
+* `Hummingbird::DOM` (DOM node model, in `src/core/dom`)
+* `Hummingbird::Geometry` (shared geometry PODs, in `src/core/geometry`)
+* `Hummingbird::Html` (tokenizer/parser)
+* `Hummingbird::Css` (CSS parsing, cascade, computed style, in `src/style`)
+* `Hummingbird::Layout` (render tree, block/inline/table flow)
+* `Hummingbird::Renderer` (display list, painter)
+* `Hummingbird::Engine` (tab, document pipeline, resources, extensions)
+* `Hummingbird::Platform` (SDL/Blend2D/curl/QuickJS adapters)
+* `Hummingbird::App` (browser chrome and wiring)
 
 ---
 

--- a/doc/tech_debt_game_plan.md
+++ b/doc/tech_debt_game_plan.md
@@ -1,4 +1,8 @@
-# Tech Debt Game Plan (Temp)
+# Tech Debt Game Plan
+
+Tracked refactoring seams. When touching a file listed here, prefer the planned
+decomposition over ad-hoc changes; check items off (with a note) when they land or
+are superseded.
 
 ## Chokepoint Candidates
 - [x] **Engine::DocumentPipeline**: narrow the public API surface so Tab talks to smaller, purpose-built interfaces (render/layout vs interaction). *(Superseded: the `LayoutApi`/`InteractionApi` facades were pure pass-throughs that tripled each method declaration; flattened back to a single grouped public API.)*

--- a/doc/todo_archive/refactoring_stories_done.md
+++ b/doc/todo_archive/refactoring_stories_done.md
@@ -1,3 +1,9 @@
+# Refactoring Stories (Archived 2026-07)
+
+Early-days audit stories (R.1–R.9). All shipped across Milestones 0–5: the dependency
+firewall is test-enforced, tokenizers are `string_view`-based, arena allocation is
+factory-enforced, and tests run headless in CI. Kept for historical reference.
+
 1. Architecture & Modularity (The "Loose Coupling" Check)
 
     Story R.1: Dependency Injection Audit


### PR DESCRIPTION
## Summary

Review pass over the agent-facing and contributor docs (AGENTS.md, coding constitution, README, dev guides, and related planning files), tightening them for accuracy and removing redundancy ahead of the release tag.

- **AGENTS.md** — rewritten from a loose bullet list into a structured entry point: document map (constitution, roadmap/active milestone, TODOs, dev guides, tech-debt plan), workflow rules (roadmap-conflict escalation, out-of-scope story capture, commit convention), and the canonical build/test/format commands. Deliberately thin — it points to the constitution rather than restating it.
- **coding_constitution.md** — removed the leftover chat-transcript preamble ("This is an excellent idea… save this as DESIGN_GUIDE.md"); broadened the Ports & Adapters rule from 3 modules to all platform-free modules (verified: only `src/platform` includes platform headers) with a pointer to `tests/core/DependencyFirewall.test.cpp`; replaced the 4-entry namespace list with the full real inventory (Core/DOM/Geometry/Html/Css/Layout/Renderer/Engine/Platform/App).
- **README.md** — added a Documentation section linking roadmap, TODOs, constitution, dev guides, and AGENTS.md (previously the README never mentioned the roadmap at all).
- **refactoring_stories.md** — archived to `doc/todo_archive/refactoring_stories_done.md` with a closure note; all R.1–R.9 stories shipped during M0–M5 and the file was referenced nowhere.
- **tech_debt_game_plan.md** — dropped the "(Temp)" title and stated its usage contract; now discoverable via AGENTS.md.
- **.gitignore** — ignore `cmake_test_discovery_*.json` (test-discovery artifacts appearing in the repo root); removed the no-op self-ignore line.

No source changes; CI docs-skip should apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
