### PR TITLE
docs: release prep for 0.6.0 (Milestone 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.0] - 2026-07-17
+
+Milestone 6 — "The Layouter": real-page layout compatibility. The DuckDuckGo HTML
+homepage now renders close to a reference browser.
+
+### Added
+
+- **CSS Flexbox** layout: `flex-direction` (+reverse), `flex-wrap` (+wrap-reverse), `justify-content`, `align-items` (including baseline), `flex-grow/shrink/basis`, the `flex` shorthand, and `order`.
+- **CSS Grid** layout (MVP): `grid-template-columns/rows` with `px/%/fr/repeat()`, `gap`/`row-gap`/`column-gap`, row-major auto-placement, and line/span placement.
+- **`@font-face` web fonts**: local and remote TrueType/OpenType, fetched through the resource pipeline (WOFF2 deferred).
+- CSS-wide `inherit`, `var()` for non-color properties, `!important`, sibling combinators (`~`/`+`), and additive `calc()` lengths.
+- Legacy CSS compatibility slice: `visibility`, `pointer-events`, `text-shadow`, and legacy `clip: rect()`.
+- Visited-link state (`:visited` / `vlink`); absolute centering with opposing insets + auto margins.
+- F1 debug hit-inspect (logs the element and its geometry to the console); DOM-budget error page.
+
+### Improved
+
+- Control chrome: border/radius longhands, per-side border colors, and vendor-prefix alias handling (prefixed-property noise is now silenced instead of warned).
+- `background` shorthand `position/size` syntax and percentage/`auto` `background-size`.
+- Selector matching accelerated with a key-selector index; resource updates coalesced into fewer restyle/layout passes; media conditions re-evaluated on viewport resize.
+- Architecture: graphics value types moved out of the platform-port header so the style layer no longer depends on the port; clang-uml architecture diagrams scoped and de-noised.
+
+### Security
+
+- Asset-origin firewall: page-controlled URLs can never reach filesystem/asset APIs (UNC/drive/traversal/absolute forms rejected).
+- Raw-text tokenizing for `<script>`/`<style>` so markup-looking strings in JS/CSS no longer spawn phantom tags or resource requests.
+
+### Guardrails
+
+- Real DuckDuckGo HTML snapshot end-to-end regression harness in CI (focus/type/submit/navigate).
+- Package dependency-cycle detection in CI.
+
+### Deferred
+
+- WOFF2 web-font decoding, grid `repeat()`-anywhere / `minmax()`, and the perf/memory architecture (offscreen raster cache, tab resource eviction, DOM virtualization) are tracked in `doc/TODOs.md` (M9/M12/M14).
+
 ## [0.5.0] - 2026-02-10
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(Hummingbird VERSION 0.5.0)
+project(Hummingbird VERSION 0.6.0)
 
 # Set C++ standard to C++20
 set(CMAKE_CXX_STANDARD 20)

--- a/NOTICE
+++ b/NOTICE
@@ -1,6 +1,6 @@
 Hummingbird Browser Engine
 
-Copyright 2025 Michal "Dvorka" Dvorak
+Copyright 2025-2026 Michal "Dvorka" Dvorak
 
 This product includes third-party components. See `assets/fonts/Roboto-LICENSE.txt`
 and the license notices packaged under `licenses/` in release artifacts.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Hummingbird is an experimental browser engine built from scratch in C++20 (HTML 
 
 Stub site + navigation demo:
 
-![Stub site and navigation demo](https://github.com/user-attachments/assets/98e01801-d678-40fd-ab7c-190b68502075)
+![Stub site and navigation demo](https://github.com/user-attachments/assets/92abcdc5-51d3-4af6-9a8f-bd78394fba68)
 
 ## Status / expectations
 
@@ -24,9 +24,10 @@ This is an early prototype:
 - CSS parsing for a subset of selectors/properties, including `<style>` blocks and external stylesheets.
 - Resource pipeline for HTML/CSS/images/SVG with incremental restyles as data arrives.
 - URL normalization + relative URL resolution for linked resources.
-- Block + inline layout, list markers, table layout, and key positioning/box-model features (including percent sizing/positioning and table width-hint balancing).
+- Block, inline, **flexbox**, and **CSS grid** layout, list markers, table layout, and key positioning/box-model features (including percent sizing/positioning, `calc()` lengths, absolute-centering, and table width-hint balancing).
 - Form controls (`<form>`, `<input>`, `<button>`), focus/editing, `autofocus`, GET+POST submit flows, and external submit controls.
-- Real-page CSS polish coverage including border-radius/outline/box-shadow, text effects, overflow handling, cursor, and vertical-align.
+- Real-page CSS polish coverage including border-radius/outline/box-shadow, text effects, overflow handling, cursor, and vertical-align, plus `visibility`, `pointer-events`, `text-shadow`, legacy `clip`, `!important`, `var()`, `inherit`, sibling combinators (`~`/`+`), and `:visited` link styling.
+- **Web fonts** via `@font-face` (local and remote TrueType/OpenType; WOFF2 not yet).
 - Background images and basic transforms used by real-world pages.
 - QuickJS integration with `onclick`/`load` dispatch and basic DOM mutation bindings.
 - Painting via Blend2D into an SDL2 window.


### PR DESCRIPTION
Release-prep for the 0.6.0 tag (Milestone 6 - The Layouter):

- README `What works today` refreshed with flexbox, CSS grid, `@font-face` web fonts, and the CSS compatibility slice (plus the DuckDuckGo demo video).
- CHANGELOG `[0.6.0]` entry.
- NOTICE copyright extended to 2025-2026.
- CMake project version bumped 0.5.0 -> 0.6.0.

No code changes; the version bump re-runs the build matrix. After merge, tag `v0.6.0` on master to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)